### PR TITLE
[Fe/#106] layout grid template

### DIFF
--- a/fe/src/App.css
+++ b/fe/src/App.css
@@ -1,42 +1,4 @@
 #root {
-  max-width: 1280px;
+  max-width: 100%;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
-}
-
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
-}
-
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
-}
-
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
-}
-
-.card {
-  padding: 2em;
-}
-
-.read-the-docs {
-  color: #888;
 }

--- a/fe/src/components/block/sideBar/SideBar.tsx
+++ b/fe/src/components/block/sideBar/SideBar.tsx
@@ -1,9 +1,16 @@
 import Text from "@components/atom/Text";
 import QuestionIcon from "@components/atom/icon/QuestionIcon";
+import useTabStore, { TabType } from "@store/useTabStore";
 import { flexCenter } from "@styles/flexCenter";
 import styled from "styled-components";
 
 const SideBar = () => {
+  const { setTabType, tabType } = useTabStore();
+
+  const handleClickTab = (word: TabType) => {
+    setTabType(word);
+  };
+
   return (
     <SideBarContainer>
       <SideBarHeader></SideBarHeader>
@@ -12,23 +19,27 @@ const SideBar = () => {
           Menu
         </Text>
         <MenuTabContainer>
-          <TabButton>
+          <TabButton isActive={tabType === "question"} onClick={() => handleClickTab("question")}>
             <Text fontSize="lg" fontWeight="bold">
-              <QuestionIcon />
               Question
             </Text>
           </TabButton>
-          <TabButton>
+          <TabButton isActive={tabType === "review"} onClick={() => handleClickTab("review")}>
             <Text fontSize="lg" fontWeight="bold">
               Review
             </Text>
           </TabButton>
-          <TabButton>
+          <TabButton isActive={tabType === "setting"} onClick={() => handleClickTab("setting")}>
             <Text fontSize="lg" fontWeight="bold">
               Setting
             </Text>
           </TabButton>
-          <TabButton>
+          <TabButton
+            isActive={tabType === null}
+            onClick={() => {
+              handleClickTab(null);
+            }}
+          >
             <Text fontSize="lg" fontWeight="bold">
               SignOut
             </Text>
@@ -68,14 +79,18 @@ const SideBarFooter = styled.div`
 const MenuTabContainer = styled.div`
   display: flex;
   flex-direction: column;
+  gap: 0.5rem;
 `;
 
-const TabButton = styled.button`
-  background-color: ${({ theme }) => theme.backgroundColor.grey3};
+const TabButton = styled.button<{ isActive: boolean }>`
+  background-color: ${({ isActive, theme }) => (isActive ? theme.backgroundColor.green3 : theme.backgroundColor.grey3)};
   border: none;
   border-radius: 4px;
   padding: 0.5rem;
   cursor: pointer;
+  color: ${({ isActive, theme }) => (isActive ? theme.backgroundColor.white : theme.backgroundColor.black)}; // Change color based on isActive
+  font-weight: ${({ isActive }) => (isActive ? "600" : "normal")}; // Change font-weight based on isActive
+
   &:hover {
     background-color: ${({ theme }) => theme.backgroundColor.green3};
     color: white;

--- a/fe/src/components/block/sideBar/SideBar.tsx
+++ b/fe/src/components/block/sideBar/SideBar.tsx
@@ -8,24 +8,30 @@ const SideBar = () => {
     <SideBarContainer>
       <SideBarHeader></SideBarHeader>
       <SideBarContent>
-        <Text color="black" fontWeight="bold" fontSize="base">
+        <Text fontSize="lg" color="black" fontWeight="bold">
           Menu
         </Text>
         <MenuTabContainer>
           <TabButton>
-            <Text fontWeight="bold">
+            <Text fontSize="lg" fontWeight="bold">
               <QuestionIcon />
               Question
             </Text>
           </TabButton>
           <TabButton>
-            <Text fontWeight="bold">Review</Text>
+            <Text fontSize="lg" fontWeight="bold">
+              Review
+            </Text>
           </TabButton>
           <TabButton>
-            <Text fontWeight="bold">Setting</Text>
+            <Text fontSize="lg" fontWeight="bold">
+              Setting
+            </Text>
           </TabButton>
           <TabButton>
-            <Text fontWeight="bold">SignOut</Text>
+            <Text fontSize="lg" fontWeight="bold">
+              SignOut
+            </Text>
           </TabButton>
         </MenuTabContainer>
       </SideBarContent>
@@ -67,6 +73,8 @@ const MenuTabContainer = styled.div`
 const TabButton = styled.button`
   background-color: ${({ theme }) => theme.backgroundColor.grey3};
   border: none;
+  border-radius: 4px;
+  padding: 0.5rem;
   cursor: pointer;
   &:hover {
     background-color: ${({ theme }) => theme.backgroundColor.green3};

--- a/fe/src/components/block/sideBar/SideBar.tsx
+++ b/fe/src/components/block/sideBar/SideBar.tsx
@@ -1,5 +1,4 @@
 import Text from "@components/atom/Text";
-import QuestionIcon from "@components/atom/icon/QuestionIcon";
 import useTabStore, { TabType } from "@store/useTabStore";
 import { flexCenter } from "@styles/flexCenter";
 import styled from "styled-components";

--- a/fe/src/components/layout/GridTemplate.tsx
+++ b/fe/src/components/layout/GridTemplate.tsx
@@ -7,8 +7,11 @@ const GridTemplate = () => {
       <div>
         <SideBar />
       </div>
-      <div>Main</div>
-      <div>RightBar</div>
+      <MainWrapper>
+        <TopHeader>Topbar</TopHeader>
+        <MainContent>Main</MainContent>
+        <RightContent>RightBar</RightContent>
+      </MainWrapper>
     </LayoutWrapper>
   );
 };
@@ -19,5 +22,27 @@ const LayoutWrapper = styled.div`
   width: 100vw;
   height: 100vh;
   display: grid;
-  grid-template-columns: 2fr 7fr 3fr;
+  grid-template-columns: 2fr 10fr;
+  grid-template-areas: "Sidebar";
+`;
+const MainWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 1fr 9fr; /* Updated grid-template-rows */
+  grid-template-columns: 10fr;
+`;
+
+const TopHeader = styled.div`
+  grid-column: 1 / span 10;
+  grid-row: 1 / 2;
+`;
+
+const MainContent = styled.div`
+  display: inline;
+  grid-column: 2 / span 7;
+  grid-row: 2 / 10; /* Updated grid-row */
+`;
+
+const RightContent = styled.div`
+  grid-column: 2 / span 3; /* Updated grid-column */
+  grid-row: 2 / 10; /* Updated grid-row */
 `;

--- a/fe/src/components/layout/GridTemplate.tsx
+++ b/fe/src/components/layout/GridTemplate.tsx
@@ -1,0 +1,23 @@
+import SideBar from "@components/block/sideBar/SideBar";
+import styled from "styled-components";
+
+const GridTemplate = () => {
+  return (
+    <LayoutWrapper>
+      <div>
+        <SideBar />
+      </div>
+      <div>Main</div>
+      <div>RightBar</div>
+    </LayoutWrapper>
+  );
+};
+
+export default GridTemplate;
+
+const LayoutWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 2fr 7fr 3fr;
+`;

--- a/fe/src/index.css
+++ b/fe/src/index.css
@@ -1,68 +1,11 @@
-:root {
-  font-family: Inter, system-ui, Avenir, Helvetica, Arial, sans-serif;
-  line-height: 1.5;
-  font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
+    sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
-}
-
-body {
-  margin: 0;
-  display: flex;
-  place-items: center;
-  min-width: 320px;
-  min-height: 100vh;
-}
-
-h1 {
-  font-size: 3.2em;
-  line-height: 1.1;
-}
-
-button {
-  border-radius: 8px;
-  border: 1px solid transparent;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  background-color: #1a1a1a;
-  cursor: pointer;
-  transition: border-color 0.25s;
-}
-button:hover {
-  border-color: #646cff;
-}
-button:focus,
-button:focus-visible {
-  outline: 4px auto -webkit-focus-ring-color;
-}
-
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+code {
+  font-family: source-code-pro, Menlo, Monaco, Consolas, "Courier New", monospace;
 }

--- a/fe/src/page/TestPageTwo.tsx
+++ b/fe/src/page/TestPageTwo.tsx
@@ -1,5 +1,5 @@
 import Text from "@components/atom/Text";
-import IconBox from "@components/atom/icon/IconBox";
+// import IconBox from "@components/atom/icon/IconBox";
 import QuestionIcon from "@components/atom/icon/QuestionIcon";
 import BackgroundModal from "@components/block/modal/BackgroundModal";
 import SideBar from "@components/block/sideBar/SideBar";

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -5,6 +5,7 @@ import Index from "@page/Index";
 import { Route, Routes } from "react-router-dom";
 import TestPage from "@page/TestPage";
 import TestPageTwo from "@page/TestPageTwo";
+import GridTemplate from "@components/layout/GridTemplate";
 
 const Router = () => {
   return (
@@ -15,6 +16,7 @@ const Router = () => {
       <Route path="/*" element={<NotFound />} />
       <Route path="/test" element={<TestPage />} />
       <Route path="/test2" element={<TestPageTwo />} />
+      <Route path="/grid" element={<GridTemplate />} />
     </Routes>
   );
 };

--- a/fe/src/store/useTabStore.ts
+++ b/fe/src/store/useTabStore.ts
@@ -1,0 +1,22 @@
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+
+export type TabType = "question" | "review" | "setting" | null;
+
+interface TabState {
+  tabType: TabType;
+}
+
+interface TabAction {
+  setTabType: (tabType: TabType) => void;
+}
+
+const useTabStore = create<TabState & TabAction>()(
+  devtools((set) => ({
+    tabType: null,
+
+    setTabType: (tabType: TabType) => set({ tabType }),
+  }))
+);
+
+export default useTabStore;

--- a/fe/src/styles/theme.ts
+++ b/fe/src/styles/theme.ts
@@ -1,6 +1,6 @@
 import { DefaultTheme } from "styled-components";
 
-export type FontSizeType = "xs" | "sm" | "base" | "lg" | "xl" | "xxl" | "xxxl";
+export type FontSizeType = "xxs" | "xs" | "sm" | "base" | "lg" | "xl" | "xxl";
 
 export type BackgroundColorType = "green1" | "green2" | "green3" | "grey1" | "grey2" | "grey3" | "black" | "white";
 


### PR DESCRIPTION
🎫 연관 티켓 
---
#106 

🙏 작업
----
- GridTemplate 추가 
- GridTemplate 양식 맟춰서 Sidebar - mainWrapper(Topbar - MainContent/RightCotent)

💁‍♂️ 어떻게?
----
- 피그마 기준으로 작업을 진행하였습니다.
- 전체적인 Column 비율은 2:7:3 으로 진행을 하였습니다. 
- Main 부분에 들어가는 글을 알림 버튼을 포함한 Topbar는 고민 끝에 Absolute로 박아 넣는 거 보다는 GridTemplate에 포함해서 넣는 편이 좋을 것 같아서 포함해서 작업을 진행했습니다. 

🙈 PR 참고 사항
----
- 세부적인 Component 들어가는 부분은 작업이 추가로 필요할 것 같습니다. 
- Common으로 박아두고 진행하는 방식도 나쁘지는 않을거 같은데 이건 고민 해보고 적용하는 걸로 

📸 스크린샷
----
<img width="1903" alt="스크린샷 2024-01-17 오후 4 00 59" src="https://github.com/sgdevcamp2023/recycle/assets/39644976/e57a320c-bef8-4431-bde4-fc503f94cadb">

🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료