### PR TITLE
[Fe/#125] RegisterEmailModal 구현

### DIFF
--- a/fe/src/components/atom/Button/RegisterButton.tsx
+++ b/fe/src/components/atom/Button/RegisterButton.tsx
@@ -1,0 +1,34 @@
+import styled from 'styled-components';
+
+const CommonStyleButton = styled.button`
+  width: 22.375rem;
+  height: 3rem;
+  padding: 1rem;
+  background-color: #1eb649;
+  color: white;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: all 0.5s;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 600;
+
+  &:hover {
+    background-color: white;
+    border: 0.063rem solid #1eb649;
+    color: #1eb649;
+  }
+`;
+
+const RegisterButton = () => {
+  return (
+    <div>
+      <CommonStyleButton>인증하기</CommonStyleButton>
+    </div>
+  );
+};
+
+export default RegisterButton;

--- a/fe/src/components/block/modal/RegisterEmailModal.tsx
+++ b/fe/src/components/block/modal/RegisterEmailModal.tsx
@@ -1,0 +1,78 @@
+import RegisterButton from '@components/atom/Button/RegisterButton';
+import CommonInput from '@components/atom/Input/CommonInput';
+import Text from '@components/atom/Text';
+import { flexCenter } from '@styles/flexCenter';
+import styled from 'styled-components';
+
+const LoginBox = styled.div`
+  box-sizing: border-box;
+  width: 29.25rem;
+  height: 19.875rem;
+  padding: 0.25rem 16px;
+  background-color: white;
+  color: black;
+  border: 1px solid #1eb649;
+  border-radius: 10px;
+  padding-right: 55px;
+  padding-left: 3.4375rem;
+  position: relative;
+`;
+
+const FlexBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  ${flexCenter}
+  position: absolute;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: 0.5rem;
+  bottom: 7.9375rem;
+`;
+
+const ButtonBox = styled.div`
+  display: flex;
+  flex-direction: column;
+  ${flexCenter}
+  position: absolute;
+  bottom: 4.0625rem;
+`;
+
+const RegisterEmailModal = () => {
+  return (
+    <div>
+      <LoginBox>
+        <Text
+          fontSize='lg'
+          fontWeight='bold'
+          style={{
+            marginTop: '3rem',
+            marginBottom: '1.25rem',
+          }}
+        >
+          이메일 등록하기
+        </Text>
+        <FlexBox>
+          <Text
+            fontSize='base'
+            fontWeight='bold'
+            style={{
+              marginTop: '1.5rem',
+              display: 'block',
+            }}
+          >
+            이메일
+          </Text>
+          <CommonInput
+            placeholder='이메일 입력하기'
+            // value=''
+          />
+        </FlexBox>
+        <ButtonBox>
+          <RegisterButton />
+        </ButtonBox>
+      </LoginBox>
+    </div>
+  );
+};
+
+export default RegisterEmailModal;

--- a/fe/src/page/TestPageThree.tsx
+++ b/fe/src/page/TestPageThree.tsx
@@ -1,5 +1,6 @@
 import AskLoginModal from '@components/block/modal/AskLoginModal';
 import LockModal from '@components/block/modal/LockModal';
+import RegisterEmailModal from '@components/block/modal/RegisterEmailModal';
 import SaveModal from '@components/block/modal/SaveModal';
 import SharingModal from '@components/block/modal/SharingModal';
 import ShowReviewerModal from '@components/block/modal/ShowReviewerModal';
@@ -21,7 +22,8 @@ const TestPageThree = () => {
         {/* <SaveModal /> */}
         {/* <ShowReviewerModal /> */}
         {/* <SharingModal /> */}
-        <LockModal />
+        {/* <LockModal /> */}
+        <RegisterEmailModal />
       </CenterModalBox>
     </>
   );


### PR DESCRIPTION
🎫 연관 티켓 
---
#125 

🙏 작업
----
- RegisterEmailModal 구현

💁‍♂️ 어떻게?
----
- 공통 컴포넌트 이용


🙈 PR 참고 사항
----
- 버튼이 하나 더 추가되었습니다
  - RegisterButton.tsx
  - (의문의 아토믹 디자인 패턴에 죄송합니다 @krokerdile) 

📸 스크린샷
----
<img width="976" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/acfad447-e316-4a43-a3ab-68a3bc444919">





🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료