### PR TITLE
[Fe/#122] tab components

### DIFF
--- a/fe/src/components/block/navbar/ContentTab.tsx
+++ b/fe/src/components/block/navbar/ContentTab.tsx
@@ -1,0 +1,57 @@
+import Text from "@components/atom/Text";
+import { useState } from "react";
+import styled from "styled-components";
+
+const ContentTab = () => {
+  const [key, setKey] = useState("");
+  return (
+    <ContentTabWrapper>
+      <Text color="grey" fontSize="base">
+        Edited Jan 03, 2024
+      </Text>
+      <TabButton
+        isActive={key == "review"}
+        onClick={() => {
+          setKey("review");
+        }}
+      >
+        review
+      </TabButton>
+      <TabButton
+        isActive={key == "share"}
+        onClick={() => {
+          setKey("share");
+        }}
+      >
+        share
+      </TabButton>
+      <TabButton
+        isActive={key == "save"}
+        onClick={() => {
+          setKey("save");
+        }}
+      >
+        save
+      </TabButton>
+    </ContentTabWrapper>
+  );
+};
+
+export default ContentTab;
+
+const ContentTabWrapper = styled.div`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 4px;
+`;
+
+const TabButton = styled.div<{ isActive: boolean }>`
+  padding: 8px;
+  cursor: pointer;
+  color: black;
+  border-radius: 8px;
+  &:hover {
+    background-color: ${({ theme }) => theme.backgroundColor.grey400};
+  }
+`;

--- a/fe/src/components/block/navbar/DefaultTab.tsx
+++ b/fe/src/components/block/navbar/DefaultTab.tsx
@@ -1,0 +1,60 @@
+import useTabStore, { DefaultTabType } from "@store/useTabStore";
+import { useState } from "react";
+import styled from "styled-components";
+
+interface DefaultTabProps {
+  items: Record<string, DefaultTabType>;
+}
+
+interface ItemProps {
+  key: string;
+  label: DefaultTabType;
+}
+
+const DefaultTab = ({ items }: DefaultTabProps) => {
+  const [activeKey, setActiveKey] = useState(Object.keys(items)[0]);
+
+  const { setDefaultTabType } = useTabStore();
+
+  const handleItemClick = ({ key, label }: ItemProps) => {
+    console.log(key, label);
+    setActiveKey(key);
+    setDefaultTabType(label);
+  };
+
+  return (
+    <TabWrapper>
+      <NavbarContainer>
+        {Object.entries(items).map(([key, label]) => (
+          <NavItem key={key} isActive={key === activeKey} onClick={() => handleItemClick({ key, label })}>
+            {key}
+          </NavItem>
+        ))}
+      </NavbarContainer>
+    </TabWrapper>
+  );
+};
+
+export default DefaultTab;
+
+const TabWrapper = styled.div`
+  width: auto;
+  height: 4rem;
+`;
+
+const NavbarContainer = styled.div`
+  display: flex;
+  background-color: white;
+  padding: 10px;
+`;
+
+const NavItem = styled.div<{ isActive: boolean }>`
+  padding: 8px 16px;
+  cursor: pointer;
+  color: ${({ isActive }) => (isActive ? "#000" : "#888")};
+  border-radius: 8px;
+  &:hover {
+    background-color: ${({ theme }) => theme.backgroundColor.green300};
+    color: white;
+  }
+`;

--- a/fe/src/page/TestPageTwo.tsx
+++ b/fe/src/page/TestPageTwo.tsx
@@ -3,6 +3,7 @@ import DefaultCard from "@components/atom/card/DefaultCard";
 import ReviewCard from "@components/atom/card/ReviewCard";
 // import IconBox from "@components/atom/icon/IconBox";
 import BackgroundModal from "@components/block/modal/BackgroundModal";
+import ContentTab from "@components/block/navbar/ContentTab";
 import DefaultTab from "@components/block/navbar/DefaultTab";
 import SideBar from "@components/block/sideBar/SideBar";
 import useModalStore from "@store/useModalStore";
@@ -46,6 +47,9 @@ const TestPageTwo = () => {
       </div>
       <div>
         <DefaultTab items={items} />
+      </div>
+      <div>
+        <ContentTab />
       </div>
     </>
   );

--- a/fe/src/page/TestPageTwo.tsx
+++ b/fe/src/page/TestPageTwo.tsx
@@ -3,8 +3,10 @@ import DefaultCard from "@components/atom/card/DefaultCard";
 import ReviewCard from "@components/atom/card/ReviewCard";
 // import IconBox from "@components/atom/icon/IconBox";
 import BackgroundModal from "@components/block/modal/BackgroundModal";
+import DefaultTab from "@components/block/navbar/DefaultTab";
 import SideBar from "@components/block/sideBar/SideBar";
 import useModalStore from "@store/useModalStore";
+import { DefaultTabType } from "@store/useTabStore";
 import { Suspense } from "react";
 import styled from "styled-components";
 
@@ -13,6 +15,8 @@ const TestPageTwo = () => {
   const handleOnClickModal = () => {
     setShowModal(!showModal);
   };
+
+  const items: Record<string, DefaultTabType> = { "내가 작성한 질문": "myQuestion", "임시 저장": "questionDrafts" };
   return (
     <>
       <div>
@@ -39,6 +43,9 @@ const TestPageTwo = () => {
       </div>
       <div>
         <ReviewCard></ReviewCard>
+      </div>
+      <div>
+        <DefaultTab items={items} />
       </div>
     </>
   );

--- a/fe/src/store/useTabStore.ts
+++ b/fe/src/store/useTabStore.ts
@@ -2,20 +2,35 @@ import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
 export type TabType = "question" | "review" | "setting" | null;
+export type QuestionTabType = "myQuestion" | "questionDrafts" | null; //내 질문 - 임시보관 - 빈 선택지
+export type ReviewTabType = "myReview" | "reviewDrafts" | null; //내 리뷰 - 임시보관 - 빈 선택지
+export type DefaultTabType = "myQuestion" | "questionDrafts" | "myReview" | "reviewDrafts" | null;
 
 interface TabState {
   tabType: TabType;
+  questionTabType: QuestionTabType;
+  reviewTabType: ReviewTabType;
+  defaultTabType: DefaultTabType;
 }
 
 interface TabAction {
   setTabType: (tabType: TabType) => void;
+  setQuestionTabType: (questionTabType: QuestionTabType) => void;
+  setReviewTabType: (reviewTabType: ReviewTabType) => void;
+  setDefaultTabType: (defaultTabType: DefaultTabType) => void;
 }
 
 const useTabStore = create<TabState & TabAction>()(
   devtools((set) => ({
     tabType: null,
+    questionTabType: null,
+    reviewTabType: null,
+    defaultTabType: null,
 
     setTabType: (tabType: TabType) => set({ tabType }),
+    setQuestionTabType: (questionTabType: QuestionTabType) => set({ questionTabType }),
+    setReviewTabType: (reviewTabType: ReviewTabType) => set({ reviewTabType }),
+    setDefaultTabType: (defaultTabType: DefaultTabType) => set({ defaultTabType }),
   }))
 );
 

--- a/fe/src/styles/theme.ts
+++ b/fe/src/styles/theme.ts
@@ -6,7 +6,7 @@ export type BackgroundColorType = "green100" | "green200" | "green300" | "grey10
 
 export type borderColorType = "black" | "grey" | "green";
 
-export type ColorType = "black" | "white" | "inherit" | "green";
+export type ColorType = "black" | "white" | "inherit" | "green" | "grey";
 
 const theme: DefaultTheme = {
   fontSize: {
@@ -34,6 +34,7 @@ const theme: DefaultTheme = {
     black: "#000000",
     inherit: "inherit",
     green: "#1EB649",
+    grey: "#858585",
   },
   borderColor: {
     black: "#000",


### PR DESCRIPTION
🎫 연관 티켓 
---
#122

🙏 작업
----
- DefaultTab 추가
- ContentTab 추가

💁‍♂️ 어떻게?
----
- DefaultTab은 리뷰, 질문으로 들어갔을 때 사용하는 탭으로, 상태관리를 일단 작업 해뒀음. 
- CotentTab은 일단 리뷰 기준으로 레이아웃, 버튼 정도 작업 진행 완료 했음

🙈 PR 참고 사항
----
- 리뷰, 질문 관련 상태관리 store 에서 참고해야 되는 사항은 두개의 탭 요소들을 그냥 한번에 일단 관리하도록 적어뒀다는 점 
- 나중에 Content Tab 전부다 넣어줄 지에 대한 부분 결정 필요

📸 스크린샷
----
<img width="643" alt="스크린샷 2024-01-19 오후 4 59 49" src="https://github.com/sgdevcamp2023/recycle/assets/39644976/de5d5f82-57f3-4596-9e2f-9fc0c8045f22">

🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료