### PR TITLE
[Fe/#136] page router

### DIFF
--- a/fe/src/components/block/Content/Question.tsx
+++ b/fe/src/components/block/Content/Question.tsx
@@ -1,0 +1,9 @@
+const Question = () => {
+  return (
+    <>
+      <>question</>
+    </>
+  );
+};
+
+export default Question;

--- a/fe/src/components/block/Content/Request.tsx
+++ b/fe/src/components/block/Content/Request.tsx
@@ -1,0 +1,9 @@
+const Request = () => {
+  return (
+    <>
+      <>Request</>
+    </>
+  );
+};
+
+export default Request;

--- a/fe/src/components/block/Content/Review.tsx
+++ b/fe/src/components/block/Content/Review.tsx
@@ -1,0 +1,9 @@
+const Review = () => {
+  return (
+    <>
+      <>review</>
+    </>
+  );
+};
+
+export default Review;

--- a/fe/src/components/block/Content/Setting.tsx
+++ b/fe/src/components/block/Content/Setting.tsx
@@ -1,0 +1,9 @@
+const Setting = () => {
+  return (
+    <>
+      <>setting</>
+    </>
+  );
+};
+
+export default Setting;

--- a/fe/src/components/block/sideBar/SideBar.tsx
+++ b/fe/src/components/block/sideBar/SideBar.tsx
@@ -28,15 +28,19 @@ const SideBar = () => {
               Review
             </Text>
           </TabButton>
+          <TabButton isActive={tabType === "request"} onClick={() => handleClickTab("request")}>
+            <Text fontSize="lg" fontWeight="bold">
+              Request
+            </Text>
+          </TabButton>
           <TabButton isActive={tabType === "setting"} onClick={() => handleClickTab("setting")}>
             <Text fontSize="lg" fontWeight="bold">
               Setting
             </Text>
           </TabButton>
           <TabButton
-            isActive={tabType === null}
             onClick={() => {
-              handleClickTab(null);
+              alert("logout");
             }}
           >
             <Text fontSize="lg" fontWeight="bold">
@@ -81,7 +85,7 @@ const MenuTabContainer = styled.div`
   gap: 0.5rem;
 `;
 
-const TabButton = styled.button<{ isActive: boolean }>`
+const TabButton = styled.button<{ isActive?: boolean }>`
   background-color: ${({ isActive, theme }) => (isActive ? theme.backgroundColor.green300 : theme.backgroundColor.grey300)};
   border: none;
   border-radius: 4px;

--- a/fe/src/components/block/sideBar/SideBar.tsx
+++ b/fe/src/components/block/sideBar/SideBar.tsx
@@ -40,6 +40,7 @@ const SideBar = () => {
           </TabButton>
           <TabButton
             onClick={() => {
+              handleClickTab(null);
               alert("logout");
             }}
           >

--- a/fe/src/components/layout/GridTemplate.tsx
+++ b/fe/src/components/layout/GridTemplate.tsx
@@ -1,5 +1,6 @@
 import SideBar from "@components/block/sideBar/SideBar";
 import styled from "styled-components";
+import { Outlet } from "react-router-dom";
 
 const GridTemplate = () => {
   return (
@@ -9,7 +10,9 @@ const GridTemplate = () => {
       </div>
       <MainWrapper>
         <TopHeader>Topbar</TopHeader>
-        <MainContent>Main</MainContent>
+        <MainContent>
+          <Outlet />
+        </MainContent>
         <RightContent>RightBar</RightContent>
       </MainWrapper>
     </LayoutWrapper>
@@ -27,8 +30,8 @@ const LayoutWrapper = styled.div`
 `;
 const MainWrapper = styled.div`
   display: grid;
-  grid-template-rows: 1fr 9fr; /* Updated grid-template-rows */
-  grid-template-columns: 10fr;
+  grid-template-rows: 1fr 20fr; /* Updated grid-template-rows */
+  grid-template-columns: 7fr 3fr;
 `;
 
 const TopHeader = styled.div`
@@ -38,11 +41,12 @@ const TopHeader = styled.div`
 
 const MainContent = styled.div`
   display: inline;
-  grid-column: 2 / span 7;
-  grid-row: 2 / 10; /* Updated grid-row */
+  grid-column: 1 / span 7;
+  grid-row: 2 / span 20; /* Updated grid-row */
+  max-width: 70%;
 `;
 
 const RightContent = styled.div`
   grid-column: 2 / span 3; /* Updated grid-column */
-  grid-row: 2 / 10; /* Updated grid-row */
+  grid-row: 2 / span 20; /* Updated grid-row */
 `;

--- a/fe/src/page/Common.tsx
+++ b/fe/src/page/Common.tsx
@@ -1,7 +1,31 @@
+import useTabStore from "@store/useTabStore";
+import { Suspense, lazy, useEffect, useState } from "react";
+
+const QuestionBody = lazy(() => import("@components/block/Content/Question"));
+const ReviewBody = lazy(() => import("@components/block/Content/Review"));
+const SettingBody = lazy(() => import("@components/block/Content/Setting"));
+const RequestBody = lazy(() => import("@components/block/Content/Request"));
+
+const Cotent = {
+  question: <QuestionBody />,
+  review: <ReviewBody />,
+  request: <RequestBody />,
+  setting: <SettingBody />,
+};
+
 const Common = () => {
+  const [selectedContent, setSelectedContent] = useState<React.ReactNode | null>(null);
+  const { tabType } = useTabStore();
+  useEffect(() => {
+    if (tabType != null) {
+      setSelectedContent(Cotent[tabType]);
+    }
+  }, [tabType]);
   return (
     <>
       <h1> Common</h1>
+      {tabType}
+      <Suspense fallback={null}>{selectedContent}</Suspense>
     </>
   );
 };

--- a/fe/src/page/Common.tsx
+++ b/fe/src/page/Common.tsx
@@ -1,0 +1,9 @@
+const Common = () => {
+  return (
+    <>
+      <h1> Common</h1>
+    </>
+  );
+};
+
+export default Common;

--- a/fe/src/page/Index.tsx
+++ b/fe/src/page/Index.tsx
@@ -1,9 +1,0 @@
-const Index = () => {
-  return (
-    <>
-      <h1>Index</h1>
-    </>
-  );
-};
-
-export default Index;

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -1,7 +1,7 @@
 import Login from "@page/Login";
 import NotFound from "@page/NotFound";
 import SignUp from "@page/SignUp";
-import Index from "@page/Index";
+import Common from "@page/Common";
 import { Route, Routes } from "react-router-dom";
 import TestPage from "@page/TestPage";
 import TestPageTwo from "@page/TestPageTwo";
@@ -11,10 +11,15 @@ import GridTemplate from "@components/layout/GridTemplate";
 const Router = () => {
   return (
     <Routes>
-      <Route path="/" element={<Index />} />
+      {/* 메인 페이지 */}
+      <Route element={<GridTemplate />}>
+        <Route path="/" element={<Common />} />
+      </Route>
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
       <Route path="/*" element={<NotFound />} />
+
+      {/* 테스트 페이지 */}
       <Route path="/test" element={<TestPage />} />
       <Route path="/test2" element={<TestPageTwo />} />
       <Route path="/test3" element={<TestPageThree />} />

--- a/fe/src/store/useTabStore.ts
+++ b/fe/src/store/useTabStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 
-export type TabType = "question" | "review" | "setting" | null;
+export type TabType = "question" | "review" | "request" | "setting" | null;
 export type QuestionTabType = "myQuestion" | "questionDrafts" | null; //내 질문 - 임시보관 - 빈 선택지
 export type ReviewTabType = "myReview" | "reviewDrafts" | null; //내 리뷰 - 임시보관 - 빈 선택지
 export type DefaultTabType = "myQuestion" | "questionDrafts" | "myReview" | "reviewDrafts" | null;


### PR DESCRIPTION
🎫 연관 티켓 
---
#136 

🙏 작업
----
- CommonPage 추가
- 질문, 리뷰, 요청, 설정에 대해서 라우팅 작업 진행
- Suspense/Lazy 작업 적용

💁‍♂️ 어떻게?
----
- Common 컴포넌트 안에서 SIdebar에서 고르는 탭에 따라서 띄워주도록 작업 완료
- Suspense, Lazy를 적용해보고 싶다고 생각을 해서 일단 해뒀는데, 이해가 좀 부족한 거 같아서 그 부분 추가 예정

🙈 PR 참고 사항
----
- Suspense,Lazy 관련 작업 추가 필요
- 각 페이지별 탭 상태관리 및 컴포넌트 띄워주는 작업 진행 예정 

📸 스크린샷
----
<img width="1904" alt="스크린샷 2024-01-21 오후 8 06 32" src="https://github.com/sgdevcamp2023/recycle/assets/39644976/485ffc19-d776-485e-9701-705bdd9237f4">


🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료