### PR TITLE
[Be/#100] Feat: web loggin filter 구현

### DIFF
--- a/be/web/src/main/java/com/zzaug/web/filter/MDCFilter.java
+++ b/be/web/src/main/java/com/zzaug/web/filter/MDCFilter.java
@@ -1,0 +1,50 @@
+package com.zzaug.web.filter;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.UUID;
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.catalina.connector.RequestFacade;
+import org.jboss.logging.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/** API 요청시 가장 먼저 거치며 MDC를 활용하여 로깅을 수행하는 필터 */
+@Slf4j
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class MDCFilter implements Filter {
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		Object traceId = request.getAttribute("X-ZZAUG-ID");
+		if (Objects.isNull(traceId)) {
+			traceId = UUID.randomUUID().toString();
+		} else {
+			traceId = traceId.toString();
+		}
+		MDC.put("traceId", traceId);
+		MDC.put("referer", ((RequestFacade) request).getHeader("referer"));
+		MDC.put("userAgent", ((RequestFacade) request).getHeader("user-agent"));
+		MDC.put("startTime", System.currentTimeMillis());
+		log.info(
+				"{} -> [{}] uri : {}",
+				request.getRemoteAddr(),
+				((RequestFacade) request).getMethod(),
+				((RequestFacade) request).getRequestURI());
+		chain.doFilter(request, response);
+		MDC.put("endTime", System.currentTimeMillis());
+		MDC.put(
+				"elapsedTime",
+				System.currentTimeMillis() - Long.parseLong(MDC.get("startTime").toString()));
+		log.info("requestLogging: {}", MDC.getMap());
+		MDC.clear();
+	}
+}

--- a/be/web/src/main/java/com/zzaug/web/handler/ApiControllerExceptionHandler.java
+++ b/be/web/src/main/java/com/zzaug/web/handler/ApiControllerExceptionHandler.java
@@ -1,0 +1,156 @@
+package com.zzaug.web.handler;
+
+import static com.zzaug.web.handler.ExceptionMessage.ACCESS_DENIED;
+import static com.zzaug.web.handler.ExceptionMessage.FAIL;
+import static com.zzaug.web.handler.ExceptionMessage.FAIL_AUTHENTICATION;
+import static com.zzaug.web.handler.ExceptionMessage.FAIL_NOT_FOUND;
+import static com.zzaug.web.handler.ExceptionMessage.FAIL_REQUEST;
+import static com.zzaug.web.handler.ExceptionMessage.REQUEST_INVALID_FORMAT;
+
+import com.zzaug.web.support.ApiResponse;
+import com.zzaug.web.support.ApiResponse.FailureBody;
+import com.zzaug.web.support.ApiResponseGenerator;
+import java.nio.file.AccessDeniedException;
+import java.util.List;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+import javax.validation.ValidationException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.hibernate.TypeMismatchException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.validation.BindException;
+import org.springframework.validation.ObjectError;
+import org.springframework.web.HttpMediaTypeNotAcceptableException;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
+import org.springframework.web.bind.ServletRequestBindingException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import org.springframework.web.servlet.NoHandlerFoundException;
+
+/** API 요청 처리 중 발생하는 예외를 처리하는 핸들러 */
+@Slf4j
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class ApiControllerExceptionHandler {
+
+	private final LoggingHandler loggingHandler;
+
+	@ExceptionHandler(IllegalArgumentException.class)
+	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
+			final IllegalArgumentException ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(FAIL.getCode(), FAIL.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler({
+		MethodArgumentTypeMismatchException.class,
+		TypeMismatchException.class,
+		ServletRequestBindingException.class,
+		BindException.class,
+		MethodArgumentNotValidException.class,
+		HttpRequestMethodNotSupportedException.class,
+		HttpMediaTypeNotSupportedException.class,
+		HttpMediaTypeNotAcceptableException.class,
+		HttpMessageNotReadableException.class,
+		MissingServletRequestParameterException.class,
+		ConstraintViolationException.class,
+		ValidationException.class
+	})
+	public final ApiResponse<ApiResponse.FailureBody> handleBadRequest(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return handleRequestDetails(ex);
+	}
+
+	private ApiResponse<FailureBody> handleRequestDetails(Exception ex) {
+		if (ex instanceof MethodArgumentTypeMismatchException) {
+			return handleRequestDetail((MethodArgumentTypeMismatchException) ex);
+		}
+		if (ex instanceof ConstraintViolationException) {
+			return handleRequestDetail((ConstraintViolationException) ex);
+		}
+
+		if (ex instanceof MethodArgumentNotValidException) {
+			return handleRequestDetail((MethodArgumentNotValidException) ex);
+		}
+		if (ex instanceof ValidationException) {
+			return handleRequestDetail((ValidationException) ex);
+		}
+		return ApiResponseGenerator.fail(
+				FAIL_REQUEST.getCode(), FAIL_REQUEST.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	private ApiResponse<FailureBody> handleRequestDetail(MethodArgumentTypeMismatchException ex) {
+		MethodArgumentTypeMismatchException rex = ex;
+		String requestInvalidCode = String.format(REQUEST_INVALID_FORMAT.getCode(), rex.getName());
+		return ApiResponseGenerator.fail(
+				requestInvalidCode, REQUEST_INVALID_FORMAT.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	private ApiResponse<FailureBody> handleRequestDetail(ConstraintViolationException ex) {
+		ConstraintViolationException rex = ex;
+		String message = rex.getMessage();
+		String parameter = message.split("\\.")[1].split(":")[0];
+		String requestInvalidCode = String.format(REQUEST_INVALID_FORMAT.getCode(), parameter);
+		return ApiResponseGenerator.fail(
+				requestInvalidCode, REQUEST_INVALID_FORMAT.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	private ApiResponse<FailureBody> handleRequestDetail(MethodArgumentNotValidException ex) {
+		MethodArgumentNotValidException rex = ex;
+		List<ObjectError> errors = rex.getAllErrors();
+		if (errors.size() == 1) {
+			String parameter = rex.getFieldError().getField();
+			String requestInvalidCode = String.format(REQUEST_INVALID_FORMAT.getCode(), parameter);
+			return ApiResponseGenerator.fail(
+					requestInvalidCode, REQUEST_INVALID_FORMAT.getMessage(), HttpStatus.BAD_REQUEST);
+		}
+		return ApiResponseGenerator.fail(
+				FAIL_REQUEST.getCode(), FAIL_REQUEST.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	private ApiResponse<FailureBody> handleRequestDetail(ValidationException ex) {
+		ValidationException rex = ex;
+		return ApiResponseGenerator.fail(
+				FAIL_REQUEST.getCode(), FAIL_REQUEST.getMessage(), HttpStatus.BAD_REQUEST);
+	}
+
+	@ExceptionHandler({AuthenticationException.class})
+	public ApiResponse<ApiResponse.FailureBody> handle(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(
+				FAIL_AUTHENTICATION.getCode(), FAIL_AUTHENTICATION.getMessage(), HttpStatus.UNAUTHORIZED);
+	}
+
+	@ExceptionHandler({NoHandlerFoundException.class})
+	public ApiResponse<ApiResponse.FailureBody> handleNotFound(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(
+				FAIL_NOT_FOUND.getCode(), FAIL_NOT_FOUND.getMessage(), HttpStatus.NOT_FOUND);
+	}
+
+	@ExceptionHandler({AccessDeniedException.class})
+	public ApiResponse<ApiResponse.FailureBody> handleForbidden(
+			final AccessDeniedException ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(
+				ACCESS_DENIED.getCode(), ACCESS_DENIED.getMessage(), HttpStatus.FORBIDDEN);
+	}
+
+	@ExceptionHandler(Exception.class)
+	public ApiResponse<ApiResponse.FailureBody> handleInternalServerError(
+			final Exception ex, final HttpServletRequest request) {
+		loggingHandler.writeLog(ex, request);
+		return ApiResponseGenerator.fail(
+				FAIL.getCode(), FAIL.getMessage(), HttpStatus.INTERNAL_SERVER_ERROR);
+	}
+}


### PR DESCRIPTION
🎫 연관 티켓 
---
#100

🙏 작업
----
- Web 모듈에서 요청에 따른 로그를 기록하는 필터를 구성하였습니다.


💁‍♂️ 어떻게?
----
MDC를 활용하여 요청의 시작과 끝에서 기록할 수 있는 로그를 남겼습니다.
MDC는 message diagnostic context로 멀티 클라이언트 환경에서 각 클라이언트별로 값을 구별하여 로그를 추적할 수 있도록 제공되는 map 입니다.


🙈 PR 참고 사항
----
#99에서 구현한 `ApiControllerExceptionHandler `에 대한 커밋이 동일하게 포함되어 있는데 이는 merege 이후 문제가 생긴다면 해결하도록 하겠습니다.

로그 스테시와 연결하기 위해 필요한 logback 설정 파일의 경우 추후 별도 PR을 통해 추가하도록 할 얘정입니다.

추가로 로그는 Json 형식으로 남기는 것이 추후 로그를 추적하는 것에 더 편리합니다.
관련해서 참고 할 수 있는 링크는 다음과 같습니다.  
https://bcho.tistory.com/1314

3줄 요약 
1. 객체에 toString을 정의한다.
2. ObjectMessage에 객체를 넣어 만든다.
3. ObjectMessage로 만든 것을 로그로 나타낸다.

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료