### PR TITLE
[Fe/144] 하단 댓글, 대댓글 modal 구현

### DIFF
--- a/fe/src/components/atom/Button/BelowCommentButton.tsx
+++ b/fe/src/components/atom/Button/BelowCommentButton.tsx
@@ -39,7 +39,7 @@ const BelowLongStyleButton = styled.button`
 const BelowCommentButton = () => {
   return (
     <div>
-      <BelowStyleButton>댓글 작성</BelowStyleButton>
+      {/* <BelowStyleButton>댓글 작성</BelowStyleButton> */}
       <BelowLongStyleButton>댓글 작성</BelowLongStyleButton>
     </div>
   );

--- a/fe/src/components/atom/Button/ReplyOfCommentButton.tsx
+++ b/fe/src/components/atom/Button/ReplyOfCommentButton.tsx
@@ -5,7 +5,7 @@ import minusImg from '../../../assets/icons/minus.png';
 const ReplyStyleButton = styled.button`
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: flex-start;
   width: 4rem;
   height: 1.5rem;
   color: black;
@@ -13,6 +13,9 @@ const ReplyStyleButton = styled.button`
   cursor: pointer;
   font-size: 0.6rem;
   transition: all 0.5s;
+  border: none;
+  outline: none;
+  background-color: white;
   padding: 0;
 
   &:hover {
@@ -40,10 +43,10 @@ const MinusIcon = styled.img`
 const ReplyOfCommentButton = () => {
   return (
     <div>
-      <ReplyStyleButton>
+      {/* <ReplyStyleButton>
         <PlusIcon src={plusImg} alt='Plus Icon' />
         답글 달기
-      </ReplyStyleButton>
+      </ReplyStyleButton> */}
       <ReplyStyleButton>
         <MinusIcon src={minusImg} alt='Plus Icon' />
         숨기기

--- a/fe/src/components/block/modal/BelowCommentModal.tsx
+++ b/fe/src/components/block/modal/BelowCommentModal.tsx
@@ -1,0 +1,79 @@
+import styled from 'styled-components';
+import reviewerIcon from '../../../assets/icons/reviewerIcon.png';
+import Text from '@components/atom/Text';
+import ReplyOfCommentButton from '@components/atom/button/ReplyOfCommentButton';
+
+const LoginBox = styled.div`
+  box-sizing: border-box;
+  width: 44.25rem;
+  height: 8.75rem;
+  padding: 0.875rem;
+  background-color: white;
+  color: black;
+  border: 1px solid black;
+  border-radius: 0.3125rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const UserBox = styled.div`
+  width: 42.25rem;
+  height: 3.125rem;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  /* border: 1px solid black; */
+`;
+
+const ReviewerIcon = styled.img`
+  width: 3.125rem;
+  height: 3.125rem;
+  color: #858585;
+`;
+
+const UserInfoBox = styled.div`
+  width: 5rem;
+  height: 3.125rem;
+  /* border: 1px solid black; */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+`;
+
+const CommentBox = styled.div`
+  width: 42.25rem;
+  height: 1.5rem;
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 1rem;
+  margin-bottom: 8px;
+  /* border: 1px solid black; */
+  /* position: absolute; */
+`;
+
+const BelowCommentModal = () => {
+  return (
+    <div>
+      <LoginBox>
+        <UserBox>
+          <ReviewerIcon src={reviewerIcon} />
+          <UserInfoBox>
+            <Text fontSize='base' fontWeight='bold'>
+              이규민
+            </Text>
+            <Text fontSize='xxs'>2024년 1월 22일</Text>
+          </UserInfoBox>
+        </UserBox>
+        <CommentBox>
+          <Text fontSize='xs'>죄송합니다... 열심히 하겠습니다...</Text>
+        </CommentBox>
+        <ReplyOfCommentButton />
+      </LoginBox>
+    </div>
+  );
+};
+
+export default BelowCommentModal;

--- a/fe/src/components/block/modal/BelowCommentReplyModal.tsx
+++ b/fe/src/components/block/modal/BelowCommentReplyModal.tsx
@@ -1,0 +1,96 @@
+import styled from 'styled-components';
+import reviewerIcon from '../../../assets/icons/reviewerIcon.png';
+import Text from '@components/atom/Text';
+import ReplyOfCommentButton from '@components/atom/button/ReplyOfCommentButton';
+import ReviewButton from '@components/atom/button/ReviewButton';
+import BelowCommentButton from '@components/atom/button/BelowCommentButton';
+
+const LoginBox = styled.div`
+  box-sizing: border-box;
+  width: 44.25rem;
+  height: 11.875rem;
+  padding: 0.875rem;
+  background-color: white;
+  color: black;
+  border: 1px solid black;
+  border-radius: 0.3125rem;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+`;
+
+const UserBox = styled.div`
+  width: 42.25rem;
+  height: 3.125rem;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  /* border: 1px solid black; */
+`;
+
+const ReviewerIcon = styled.img`
+  width: 3.125rem;
+  height: 3.125rem;
+  color: #858585;
+`;
+
+const UserInfoBox = styled.div`
+  width: 5rem;
+  height: 3.125rem;
+  /* border: 1px solid black; */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  margin-left: 0.5rem;
+`;
+
+const CommentBox = styled.div`
+  width: 42.25rem;
+  height: 1.5rem;
+  display: flex;
+  justify-content: flex-start;
+  margin-top: 1rem;
+  margin-bottom: 8px;
+  /* border: 1px solid black; */
+  /* position: absolute; */
+`;
+
+const ReplyButtonBox = styled.div`
+  width: 42.25rem;
+  height: 2.5rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+
+  border-top: 1px solid black;
+  position: absolute;
+  bottom: 0.25rem;
+`;
+
+const BelowCommentReplyModal = () => {
+  return (
+    <div>
+      <LoginBox>
+        <UserBox>
+          <ReviewerIcon src={reviewerIcon} />
+          <UserInfoBox>
+            <Text fontSize='base' fontWeight='bold'>
+              이규민
+            </Text>
+            <Text fontSize='xxs'>2024년 1월 22일</Text>
+          </UserInfoBox>
+        </UserBox>
+        <CommentBox>
+          <Text fontSize='xs'>죄송합니다... 열심히 하겠습니다...</Text>
+        </CommentBox>
+        <ReplyOfCommentButton />
+        <ReplyButtonBox>
+          <BelowCommentButton />
+        </ReplyButtonBox>
+      </LoginBox>
+    </div>
+  );
+};
+
+export default BelowCommentReplyModal;

--- a/fe/src/page/TestPageThree.tsx
+++ b/fe/src/page/TestPageThree.tsx
@@ -1,4 +1,6 @@
 import AskLoginModal from '@components/block/modal/AskLoginModal';
+import BelowCommentModal from '@components/block/modal/BelowCommentModal';
+import BelowCommentReplyModal from '@components/block/modal/BelowCommentReplyModal';
 import LockModal from '@components/block/modal/LockModal';
 import RegisterEmailModal from '@components/block/modal/RegisterEmailModal';
 import ReviewToGitModal from '@components/block/modal/ReviewToGitModal';
@@ -14,6 +16,7 @@ const CenterModalBox = styled.div`
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-direction: column;
 `;
 
 const TestPageThree = () => {
@@ -27,7 +30,9 @@ const TestPageThree = () => {
         {/* <LockModal /> */}
         {/* <RegisterEmailModal /> */}
         {/* <ReviewToGitModal /> */}
-        <SendEmailModal />
+        {/* <SendEmailModal /> */}
+        <BelowCommentModal />
+        <BelowCommentReplyModal />
       </CenterModalBox>
     </>
   );


### PR DESCRIPTION
🎫 연관 티켓 
---
#144 

🙏 작업
----
- BelowCommentModal 구현
- BelowCommentReplyModal 구현

💁‍♂️ 어떻게?
----
- 공통 컴포넌트 이용


🙈 PR 참고 사항
----
- 모달 두 개를 생성하였습니다
  - 이럴거면 분리할걸...
  - 버튼 컴포넌트에 수정이 들어갔습니다 

📸 스크린샷
----
<img width="976" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/fbbc9016-42cc-42fc-aca4-ccaf2a8266da">







🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료