### PR TITLE
[FE/187] TabButton 구현을 통한 Button Component style 관련 에러 해결

### DIFF
--- a/fe/src/components/atom/Button/TabButton.tsx
+++ b/fe/src/components/atom/Button/TabButton.tsx
@@ -3,7 +3,7 @@ import { BackgroundColorType, ColorType, FontSizeType, borderColorType } from '@
 import { MouseEventHandler } from 'react';
 import React from 'react';
 
-interface DefaultButtonProps {
+interface TabButtonProps {
   children?: React.ReactNode;
   width?: number | string;
   height?: number | string;
@@ -18,7 +18,7 @@ interface DefaultButtonProps {
   isTabButton?: boolean;
 }
 
-const DefaultButton = ({
+const TabButton = ({
   width = 'default',
   height = 'default',
   fontSize = 'base',
@@ -30,9 +30,9 @@ const DefaultButton = ({
   isTabButton = false,
   onClick,
   children,
-}: DefaultButtonProps) => {
+}: TabButtonProps) => {
   return (
-    <DefaultButtonBox
+    <TabButtonBox
       width={width}
       height={height}
       fontSize={fontSize}
@@ -44,13 +44,13 @@ const DefaultButton = ({
       isActive={isTabButton && isActive}
     >
       {children}
-    </DefaultButtonBox>
+    </TabButtonBox>
   );
 };
 
-const DefaultButtonBox = styled.button<
+const TabButtonBox = styled.button<
   Pick<
-    DefaultButtonProps,
+    TabButtonProps,
     | 'width'
     | 'height'
     | 'fontSize'
@@ -67,25 +67,22 @@ const DefaultButtonBox = styled.button<
   padding: ${({ padding }) => (padding === 'default' ? '1rem' : `${padding}`)};
   border: none;
   border-radius: 0.25rem;
-  color: ${({ theme, color }) => (color ? theme.color[color] : theme.color.white)};
   font-weight: 500;
   font-size: ${({ theme, fontSize }) =>
     fontSize ? theme.fontSize[fontSize] : theme.fontSize.base};
-  background-color: ${({ theme, backgroundColor }) =>
-    backgroundColor ? theme.backgroundColor[backgroundColor] : theme.backgroundColor.g};
   cursor: pointer;
   transition: all 0.5s;
-
   display: flex;
   align-items: center;
   justify-content: center;
-
+  color: ${({ isActive }) => (isActive ? 'white' : '#888')};
+  background-color: ${({ theme, isActive }) =>
+    isActive ? theme.backgroundColor.green100 : theme.backgroundColor.white};
+  border-radius: 8px;
   &:hover {
-    background-color: ${({ theme, backgroundColor }) =>
-      backgroundColor ? theme.backgroundColor.white : theme.backgroundColor.green100};
-    border: 0.063rem solid #1eb649;
-    color: ${({ theme, color }) => (color ? theme.color.green : theme.color.white)};
+    background-color: ${({ theme }) => theme.backgroundColor.green100};
+    color: white;
   }
 `;
 
-export default DefaultButton;
+export default TabButton;

--- a/fe/src/components/block/navbar/DefaultTab.tsx
+++ b/fe/src/components/block/navbar/DefaultTab.tsx
@@ -1,6 +1,7 @@
-import DefaultButton from '@components/atom/Button/DefaultButton';
+import TabButton from '@components/atom/Button/TabButton';
 import Text from '@components/atom/Text';
 import useTabStore, { DefaultTabType } from '@store/useTabStore';
+import React from 'react';
 import { useState } from 'react';
 import styled from 'styled-components';
 
@@ -29,7 +30,7 @@ const DefaultTab = ({ items }: DefaultTabProps) => {
       <NavbarContainer>
         {Object.entries(items).map(([key, label]) => (
           <NavItem isActive={key === activeKey}>
-            <DefaultButton
+            <TabButton
               key={key}
               isActive={key === activeKey}
               onClick={() => handleItemClick({ key, label })}
@@ -41,7 +42,7 @@ const DefaultTab = ({ items }: DefaultTabProps) => {
               <Text fontSize="lg" fontWeight="bold">
                 {key}
               </Text>
-            </DefaultButton>
+            </TabButton>
           </NavItem>
         ))}
       </NavbarContainer>
@@ -63,6 +64,7 @@ const NavbarContainer = styled.div`
 `;
 
 const NavItem = styled.div<{ isActive: boolean }>`
+  /* 상태에 따라 색상 및 스타일 변경 */
   color: ${({ isActive }) => (isActive ? 'white' : '#888')};
   background-color: ${({ theme, isActive }) =>
     isActive ? theme.backgroundColor.green200 : theme.backgroundColor.white};


### PR DESCRIPTION
🎫 연관 티켓 
---
#187 

🙏 작업
----
- DefaultTab과 타 Modal 간의 버튼 style 충돌을 해결하였습니다.

💁‍♂️ 어떻게?
----
```javascript
const DefaultButtonBox = styled.button<
  Pick<
    DefaultButtonProps,
    | 'width'
    | 'height'
    | 'fontSize'
    | 'color'
    | 'backgroundColor'
    | 'borderColor'
    | 'padding'
    | 'cursor'
    | 'isActive'
  >
>`
  width: ${({ width }) => (width === 'default' ? '100%' : `${width}rem`)};
  height: ${({ height }) => (height === 'default' ? '100%' : `${height}rem`)};
  padding: ${({ padding }) => (padding === 'default' ? '1rem' : `${padding}`)};
  border: none;
  border-radius: 0.25rem;
  color: ${({ theme, color }) =>
    color ? theme.color[color] : theme.color.white};
  font-weight: 500;
  font-size: ${({ theme, fontSize }) =>
    fontSize ? theme.fontSize[fontSize] : theme.fontSize.base};
  background-color: ${({ theme, backgroundColor }) =>
    backgroundColor
      ? theme.backgroundColor[backgroundColor]
      : theme.backgroundColor.white};
  cursor: pointer;
  transition: all 0.5s;

  display: flex;
  align-items: center;
  justify-content: center;

  &:hover {
    background-color: ${({ theme, backgroundColor }) =>
      backgroundColor
        ? theme.backgroundColor.white
        : theme.backgroundColor.green100};
    border: 0.063rem solid #1eb649;
    color: ${({ theme, color }) =>
      color ? theme.color.green : theme.color.white};
  }

  color: ${({ isActive }) => (isActive ? 'white' : '#888')};
  background-color: ${({ theme, isActive }) =>
    isActive ? theme.backgroundColor.green100 : theme.backgroundColor.white};
  border-radius: 8px;
  &:hover {
    background-color: ${({ theme }) => theme.backgroundColor.green100};
    color: white;
  }
`;
```
- 기존 DefaultButton을 이용해 DefaultTab 내부 버튼의 스타일까지 한번에 관리하려고 하였음
- 하지만, 보다시피 CSS가 덮어씌워진 상태였고 isActive가 default로 false로 선언되어 있어 defaultTab이 아닌 다른 Modal 들에서는 자동으로 역전된 상태의 스타일이 유지되고 있었음

### 해결하려 시도한 방법
1. css 모듈을 통한 더 많은 조건의 추가
![image](https://github.com/sgdevcamp2023/recycle/assets/102893954/dbae43e4-d8c1-42f6-a337-10e90ffa2190)
- 문제가 isActive 가 hover 조건에 들어있지 않다는 판단에 css 모듈을 통해 더 많은 조건을 추가해주려 하였음
2. isTabButton 속성 활용
```javascript
backgroun-color ${({ theme, isActive, isTabButton }) =>
  (isTabButton && isActive) ? theme.bacgroundColor.green100 : theme.backgroundColor.white)
```
- isTabButton이라는 속성을 추가해 'defaultTab'내부의 탭 버튼이라는 것을 명시하여 Active와 Tab 둘  다를 만족해야 해당 스타일이 적용되도록 합

### 실패 원인
- 결국 isActive, isTabButton 속성이 어찌 되건 default 값을 false로 놓는 순간 다른 모든 DefaultButton을 사용한 버튼들은 역전된 스타일을 가질 수 밖에 없게 되는 것이었음
  - 8시간동안 기다려준 여러분들께 감사합니다... 

🙈 PR 참고 사항
----
- Button 리팩토링 진짜 찐막입니다. 다음부터는 간단한 width, height 외에는 건드릴 일이 딱히 없을 것 같습니다.
- 추후 리팩토링을 하게 될 시에 '[버튼 상태관리](https://mesign.tistory.com/49)'를 따라가보는 것도 좋을 듯 합니다.

📸 스크린샷
----
- 기본적으로 이전 버튼들 생김새는 동일합니다.
<img width="976" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/99b4780e-deef-4758-a8bd-659a10c06120">

<img width="976" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/8523af5e-b2cc-4d4b-aabb-088a6231194e">


🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료