### PR TITLE
feat: 버튼별 라우터 적용

### DIFF
--- a/fe/src/components/block/modal/AskLoginModal.tsx
+++ b/fe/src/components/block/modal/AskLoginModal.tsx
@@ -3,6 +3,7 @@ import { flexCenter } from '@styles/flexCenter';
 import styled from 'styled-components';
 import logo from '../../../assets/logos/ZzaugLogo.png';
 import DefaultButton from '@components/atom/Button/DefaultButton';
+import useMovePage from '@hooks/common/useMovePage';
 
 const LoginBox = styled.div`
   box-sizing: border-box;
@@ -66,6 +67,7 @@ const TitleBox = styled.div`
 `;
 
 const AskLoginModal = () => {
+  const move = useMovePage();
   return (
     <div>
       <LoginBox>
@@ -87,13 +89,17 @@ const AskLoginModal = () => {
           <p>아직</p>
           <Logo src={logo} alt="zzaug main logo" />
           <p>계정이 없으신가요?</p>
-          <p
+          <Text
+            fontWeight='bold'
             style={{
               marginLeft: '0.25rem',
+              cursor: 'pointer',
+              color: '#1eb649'
             }}
+            onClick={() => move('signup')}
           >
             회원가입
-          </p>
+          </Text>
         </TextBox>
       </LoginBox>
     </div>

--- a/fe/src/components/block/modal/LoginModal.tsx
+++ b/fe/src/components/block/modal/LoginModal.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import logo from '../../../assets/logos/ZzaugLogo.png';
 import DefaultButton from '@components/atom/Button/DefaultButton';
 import CustomInput from '@components/atom/Input/CustomInput';
+import useMovePage from '@hooks/common/useMovePage';
 
 const LoginBox = styled.div`
   box-sizing: border-box;
@@ -58,6 +59,7 @@ const TextBox = styled.div`
 `;
 
 const LoginModal = () => {
+  const move = useMovePage();
   return (
     <div>
       <LoginBox>
@@ -96,13 +98,17 @@ const LoginModal = () => {
           <p>아직</p>
           <Logo src={logo} alt="zzaug main logo" />
           <p>계정이 없으신가요?</p>
-          <p
+          <Text
+            fontWeight='bold'
             style={{
               marginLeft: '0.25rem',
+              cursor: 'pointer',
+              color: '#1eb649'
             }}
+            onClick={() => move('signup')}
           >
             회원가입
-          </p>
+          </Text>
         </TextBox>
       </LoginBox>
     </div>

--- a/fe/src/components/block/modal/SendEmailModal.tsx
+++ b/fe/src/components/block/modal/SendEmailModal.tsx
@@ -2,8 +2,8 @@ import styled from 'styled-components';
 import Text from '@components/atom/Text';
 import mainLogo from '../../../assets/logos/ZzaugLogo.png';
 import phoneLogo from '../../../assets/icons/PhoneIcon.png';
-import EmailEnrollButton from '@components/atom/Button/EmailEnrollButton';
 import DefaultButton from '@components/atom/Button/DefaultButton';
+import useMovePage from '@hooks/common/useMovePage';
 
 const LoginBox = styled.div`
   box-sizing: border-box;
@@ -75,6 +75,8 @@ const Logo = styled.img`
 `;
 
 const SendEmailModal = () => {
+  const move = useMovePage();
+
   return (
     <div>
       <LoginBox>
@@ -95,7 +97,7 @@ const SendEmailModal = () => {
           </Content>
           <ButtonBox>
             {/* <EmailEnrollButton /> */}
-            <DefaultButton width={5} height={2} fontSize="xs">
+            <DefaultButton width={5} height={2} fontSize="xs" onClick={() => move('registeremail')}>
               등록하기
             </DefaultButton>
           </ButtonBox>

--- a/fe/src/hooks/common/useMovePage.ts
+++ b/fe/src/hooks/common/useMovePage.ts
@@ -1,0 +1,14 @@
+import { useNavigate } from 'react-router-dom';
+
+type PageType = 'main' | 'login' | 'signup' | 'registeremail';
+
+const useMovePage = () => {
+  const navigate = useNavigate();
+
+  const move = (page: PageType) => {
+    navigate(`/${page}`);
+  };
+  return move;
+};
+
+export default useMovePage;

--- a/fe/src/page/Main.tsx
+++ b/fe/src/page/Main.tsx
@@ -3,6 +3,7 @@ import styled, { keyframes } from 'styled-components';
 import logo from '../assets/logos/ZzaugLogo.png';
 import ReverseButton from '@components/atom/Button/ReverseButton';
 import pencil from '../assets/icons/Pencil.png';
+import useMovePage from '@hooks/common/useMovePage';
 
 const CenterModalBox = styled.div`
   box-sizing: border-box;
@@ -72,6 +73,7 @@ const PenLogo = styled.img`
 `;
 
 const Main = () => {
+  const move = useMovePage();
   return (
     <CenterModalBox>
       <TitleBox>
@@ -85,10 +87,20 @@ const Main = () => {
           </Text>
         </TextBox>
         <ButtonBox>
-          <ReverseButton width={11.25} height={3.25} borderColor={'green'}>
+          <ReverseButton
+            width={11.25}
+            height={3.25}
+            borderColor={'green'}
+            onClick={() => move('login')}
+          >
             로그인
           </ReverseButton>
-          <ReverseButton width={11.25} height={3.25} borderColor={'green'}>
+          <ReverseButton
+            width={11.25}
+            height={3.25}
+            borderColor={'green'}
+            onClick={() => move('signup')}
+          >
             회원가입
           </ReverseButton>
         </ButtonBox>

--- a/fe/src/page/RegisterEmail.tsx
+++ b/fe/src/page/RegisterEmail.tsx
@@ -1,0 +1,20 @@
+import RegisterEmailModal from '@components/block/modal/RegisterEmailModal';
+import styled from 'styled-components';
+
+const CenterModalBox = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const RegisterEmail = () => {
+  return (
+    <CenterModalBox>
+      <RegisterEmailModal />
+    </CenterModalBox>
+  );
+};
+
+export default RegisterEmail;

--- a/fe/src/page/TestPageThree.tsx
+++ b/fe/src/page/TestPageThree.tsx
@@ -12,6 +12,8 @@ import RegisterEmailModal from '@components/block/modal/RegisterEmailModal';
 import SignInModal from '@components/block/modal/SignInModal';
 
 import styled from 'styled-components';
+import RegisterEmail from './RegisterEmail';
+import SendEmailModal from '@components/block/modal/SendEmailModal';
 
 const CenterModalBox = styled.div`
   width: 100vw;
@@ -39,7 +41,8 @@ const TestPageThree = () => {
           placeholder="댓글을 작성하세요."
           fontSize="xs"
         /> */}
-        <BackgroundModal />
+        {/* <RegisterEmail/> */}
+        <SendEmailModal/>
       </CenterModalBox>
     </>
   );

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -9,6 +9,7 @@ import TestPageThree from '@page/TestPageThree';
 import GridTemplate from '@components/layout/GridTemplate';
 import BlackNoteTest from '@page/BlackNoteTest';
 import Main from '@page/Main';
+import RegisterEmail from '@page/RegisterEmail';
 
 const Router = () => {
   return (
@@ -27,6 +28,8 @@ const Router = () => {
       <Route path="/main" element={<Main />} />
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
+      <Route path="/registeremail" element={<RegisterEmail />} />
+
 
       {/* 테스트 페이지 */}
       <Route path="/test" element={<TestPage />} />

--- a/fe/vite.config.ts
+++ b/fe/vite.config.ts
@@ -24,8 +24,8 @@ export default defineConfig({
         replacement: path.resolve(__dirname, 'src/api'),
       },
       {
-        find: '@hook',
-        replacement: path.resolve(__dirname, 'src/hook'),
+        find: '@hooks',
+        replacement: path.resolve(__dirname, 'src/hooks'),
       },
       {
         find: '@styles',

--- a/fe/vite.config.ts.timestamp-1706507854540-5f6efe600778.mjs
+++ b/fe/vite.config.ts.timestamp-1706507854540-5f6efe600778.mjs
@@ -1,0 +1,53 @@
+// vite.config.ts
+import { defineConfig } from "file:///Users/kmlee/recycle/fe/node_modules/vite/dist/node/index.js";
+import react from "file:///Users/kmlee/recycle/fe/node_modules/@vitejs/plugin-react/dist/index.mjs";
+import path from "path";
+import svgr from "file:///Users/kmlee/recycle/fe/node_modules/vite-plugin-svgr/dist/index.js";
+var __vite_injected_original_dirname = "/Users/kmlee/recycle/fe";
+var vite_config_default = defineConfig({
+  plugins: [react(), svgr()],
+  resolve: {
+    alias: [
+      {
+        find: "@",
+        replacement: path.resolve(__vite_injected_original_dirname, "src")
+      },
+      {
+        find: "@page",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/page")
+      },
+      {
+        find: "@components",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/components")
+      },
+      {
+        find: "@api",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/api")
+      },
+      {
+        find: "@hook",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/hook")
+      },
+      {
+        find: "@styles",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/styles")
+      },
+      {
+        find: "@template",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/template")
+      },
+      {
+        find: "@store",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/store")
+      },
+      {
+        find: "@assets",
+        replacement: path.resolve(__vite_injected_original_dirname, "src/assets")
+      }
+    ]
+  }
+});
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvVXNlcnMva21sZWUvcmVjeWNsZS9mZVwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL1VzZXJzL2ttbGVlL3JlY3ljbGUvZmUvdml0ZS5jb25maWcudHNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL1VzZXJzL2ttbGVlL3JlY3ljbGUvZmUvdml0ZS5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJztcbmltcG9ydCByZWFjdCBmcm9tICdAdml0ZWpzL3BsdWdpbi1yZWFjdCc7XG5pbXBvcnQgcGF0aCBmcm9tICdwYXRoJztcbmltcG9ydCBzdmdyIGZyb20gJ3ZpdGUtcGx1Z2luLXN2Z3InO1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoe1xuICBwbHVnaW5zOiBbcmVhY3QoKSwgc3ZncigpXSxcbiAgcmVzb2x2ZToge1xuICAgIGFsaWFzOiBbXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAcGFnZScsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3BhZ2UnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAY29tcG9uZW50cycsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL2NvbXBvbmVudHMnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAYXBpJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvYXBpJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQGhvb2snLFxuICAgICAgICByZXBsYWNlbWVudDogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgJ3NyYy9ob29rJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQHN0eWxlcycsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3N0eWxlcycpLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgZmluZDogJ0B0ZW1wbGF0ZScsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3RlbXBsYXRlJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQHN0b3JlJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvc3RvcmUnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAYXNzZXRzJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvYXNzZXRzJyksXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG59KTtcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFBdVAsU0FBUyxvQkFBb0I7QUFDcFIsT0FBTyxXQUFXO0FBQ2xCLE9BQU8sVUFBVTtBQUNqQixPQUFPLFVBQVU7QUFIakIsSUFBTSxtQ0FBbUM7QUFLekMsSUFBTyxzQkFBUSxhQUFhO0FBQUEsRUFDMUIsU0FBUyxDQUFDLE1BQU0sR0FBRyxLQUFLLENBQUM7QUFBQSxFQUN6QixTQUFTO0FBQUEsSUFDUCxPQUFPO0FBQUEsTUFDTDtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsS0FBSztBQUFBLE1BQzVDO0FBQUEsTUFDQTtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsVUFBVTtBQUFBLE1BQ2pEO0FBQUEsTUFDQTtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsZ0JBQWdCO0FBQUEsTUFDdkQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxTQUFTO0FBQUEsTUFDaEQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxVQUFVO0FBQUEsTUFDakQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxZQUFZO0FBQUEsTUFDbkQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxjQUFjO0FBQUEsTUFDckQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxXQUFXO0FBQUEsTUFDbEQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxZQUFZO0FBQUEsTUFDbkQ7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUNGLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==


### PR DESCRIPTION
🎫 연관 티켓 
---
#187 

🙏 작업
----
- 회원가입, 로그인, 등록하기의 버튼에 페이지 이동을 적용했습니다.

💁‍♂️ 어떻게?
----
```javascript
import { useNavigate } from 'react-router-dom';

type PageType = 'main' | 'login' | 'signup' | 'registeremail';

const useMovePage = () => {
  const navigate = useNavigate();

  const move = (page: PageType) => {
    navigate(`/${page}`);
  };
  return move;
};

export default useMovePage;
```
- 모든 페이지들에 useNavigate를 사용하기보단 custom hook으로 더 간단하게 페이지 이동을 적용할 수 있도록 하였음
```javascript
const handleLoginClick = () => {
  move('login');
};

// ...

<ReverseButton
  width={11.25}
  height={3.25}
  borderColor={'green'}
  onClick={handleLoginClick}
>
  로그인
</ReverseButton>
```
- 위와 같은 형식으로도 사용해보려 하였으나, 함수를 호출하지 않고 직접 전달하는 방식이 코드가 더 간결해 보이는 관계로 직접 전달하는 방식을 사용하였음
 - 성능의 미세한 차이가 있다고는 함,
 함수를 호출하지 않고 바로 전달하는 경우, 매 클릭마다 이전에 생성한 함수를 재사용하므로 성능에 미세한 차이를 불러올 수는 있으나, 큰 차이가 아닌 관계로 함수 호출방식은 사용하지 않음 

🙈 PR 참고 사항
----
- vite.config.ts에 변경이 발생했습니다
 - 기존 @hook -> @hooks 로 변경했습니다. (20분 바보비용 발생)

📸 스크린샷
----
- 기본적으로 이전 버튼들 생김새는 동일합니다.
- 다만 회원가입 등의 작은 글에 링크와 스타일을 추가하였습니다.
![image](https://github.com/sgdevcamp2023/recycle/assets/102893954/903a7582-2954-4afd-887f-6a3a299d35d2)


🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료