### PR TITLE
[Fe/209] 깃허브, 이메일 계정 연동 AccountLinking 페이지 구현

### DIFF
--- a/fe/src/components/block/modal/ReviewToGitModal.tsx
+++ b/fe/src/components/block/modal/ReviewToGitModal.tsx
@@ -2,8 +2,6 @@ import styled from 'styled-components';
 import gitLogo from '../../../assets/icons/github-mark.png';
 import Text from '@components/atom/Text';
 import mainLogo from '../../../assets/logos/ZzaugLogo.png';
-import ExperienceButton from '@components/atom/Button/ExperienceButton';
-import LinkToGitButton from '@components/atom/Button/LinkToGitButton';
 import DefaultButton from '@components/atom/Button/DefaultButton';
 
 const LoginBox = styled.div`
@@ -13,7 +11,6 @@ const LoginBox = styled.div`
   padding: 0.75rem 0.625rem;
   background-color: white;
   color: black;
-  border: 1px solid black;
   position: relative;
   display: flex;
   justify-content: space-between;

--- a/fe/src/components/block/modal/SendEmailModal.tsx
+++ b/fe/src/components/block/modal/SendEmailModal.tsx
@@ -12,7 +12,6 @@ const LoginBox = styled.div`
   padding: 0.75rem 0.625rem;
   background-color: white;
   color: black;
-  border: 1px solid black;
   position: relative;
   display: flex;
   justify-content: space-between;

--- a/fe/src/page/AccountLinking.tsx
+++ b/fe/src/page/AccountLinking.tsx
@@ -1,0 +1,52 @@
+import styled from 'styled-components';
+import logo from '../assets/logos/ZzaugLogo.png';
+import Text from '@components/atom/Text';
+import ReviewToGitModal from '@components/block/modal/ReviewToGitModal';
+import SendEmailModal from '@components/block/modal/SendEmailModal';
+
+const CenterModalBox = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+const ModalBox = styled.div`
+  width: 38.75rem;
+  height: 38.25rem;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 3rem;
+`;
+
+const TextBox = styled.div`
+  width: 38.75rem;
+  height: 2.375rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`
+const Logo = styled.img`
+  height: 3rem;
+  margin-right: 0.25rem;
+`;
+
+
+const AccountLinking = () => {
+  return (
+    <CenterModalBox>
+      <ModalBox>
+        <TextBox>
+          <Logo src={logo} alt="zzaug main logo" />
+          <Text fontSize='lg' fontWeight='bold'>에서는 이런 서비스들을 제공해요!</Text>
+        </TextBox>
+        <ReviewToGitModal/>
+        <SendEmailModal/>
+      </ModalBox>
+    </CenterModalBox>
+  );
+};
+
+export default AccountLinking;

--- a/fe/src/page/AccountLinking.tsx
+++ b/fe/src/page/AccountLinking.tsx
@@ -3,14 +3,8 @@ import logo from '../assets/logos/ZzaugLogo.png';
 import Text from '@components/atom/Text';
 import ReviewToGitModal from '@components/block/modal/ReviewToGitModal';
 import SendEmailModal from '@components/block/modal/SendEmailModal';
-
-const CenterModalBox = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-`;
+import SideBar from '@components/block/sideBar/SideBar';
+import ContentTab from '@components/block/navbar/ContentTab';
 
 const ModalBox = styled.div`
   width: 38.75rem;
@@ -19,6 +13,7 @@ const ModalBox = styled.div`
   flex-direction: column;
   justify-content: center;
   gap: 3rem;
+  margin-left: 10rem;
 `;
 
 const TextBox = styled.div`
@@ -33,19 +28,64 @@ const Logo = styled.img`
   margin-right: 0.25rem;
 `;
 
+const LayoutWrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: grid;
+  grid-template-columns: 2fr 10fr;
+  grid-template-areas: 'Sidebar';
+`;
+const MainWrapper = styled.div`
+  display: grid;
+  grid-template-rows: 1fr 11fr;
+  grid-template-columns: 7fr 3fr;
+`;
+
+const TopHeader = styled.div`
+  grid-column: 1 / span 10;
+  grid-row: 1 / span 1;
+  display: flex;
+  justify-content: end;
+`;
+
+const MainContent = styled.div`
+  display: inline;
+  grid-column: 1 / span 7;
+  grid-row: 2 / span 11;
+  max-width: calc(70% - 2rem);
+  padding: 1rem;
+`;
+
+const RightContent = styled.div`
+  grid-column: 2 / span 3; /* Updated grid-column */
+  grid-row: 2 / span 20; /* Updated grid-row */
+  padding: 1rem;
+`;
+
 
 const AccountLinking = () => {
   return (
-    <CenterModalBox>
-      <ModalBox>
-        <TextBox>
-          <Logo src={logo} alt="zzaug main logo" />
-          <Text fontSize='lg' fontWeight='bold'>에서는 이런 서비스들을 제공해요!</Text>
-        </TextBox>
-        <ReviewToGitModal/>
-        <SendEmailModal/>
-      </ModalBox>
-    </CenterModalBox>
+      <LayoutWrapper>
+        <div>
+          <SideBar/>
+        </div>
+        <MainWrapper>
+          <TopHeader>
+            <ContentTab/>
+          </TopHeader>
+          <MainContent>
+            <ModalBox>
+              <TextBox>
+                <Logo src={logo} alt="zzaug main logo" />
+                <Text fontSize='lg' fontWeight='bold'>에서는 이런 서비스들을 제공해요!</Text>
+              </TextBox>
+              <ReviewToGitModal/>
+              <SendEmailModal/>
+            </ModalBox>
+          </MainContent>
+          <RightContent>RightBar</RightContent>
+        </MainWrapper>
+      </LayoutWrapper>
   );
 };
 

--- a/fe/src/routes/router.tsx
+++ b/fe/src/routes/router.tsx
@@ -10,6 +10,7 @@ import GridTemplate from '@components/layout/GridTemplate';
 import BlackNoteTest from '@page/BlackNoteTest';
 import Main from '@page/Main';
 import RegisterEmail from '@page/RegisterEmail';
+import AccountLinking from '@page/AccountLinking';
 
 const Router = () => {
   return (
@@ -29,6 +30,7 @@ const Router = () => {
       <Route path="/login" element={<Login />} />
       <Route path="/signup" element={<SignUp />} />
       <Route path="/registeremail" element={<RegisterEmail />} />
+      <Route path="/accountlinking" element={<AccountLinking />} />
 
 
       {/* 테스트 페이지 */}


### PR DESCRIPTION
🎫 연관 티켓 
---
#209 

🙏 작업
----
- AccountLinking 구현

💁‍♂️ 어떻게?
----
- 공통 컴포넌트 이용

🙈 PR 참고 사항
----
- Router에 /accountlink로 우선 라우터 처리 해놓았습니다.
- 사이드바를 추가하게 된다면, 사이드바 내부에 새로운 content 추가가 필요해 보입니다.
   - 이부분 같이 이야기해봐요! @krokerdile
   - 다른 부분들 먼저 개발하고 이부분 나중에 리팩해도 괜찮을 것 같습니다!
   - 일단 GridTemplate 내부 content outlet에는 적용하지 않고, 그냥 accountlink page로 따로 빼서 내부 컴포넌트들 가져와서 리팩토링 해봤습니다.

📸 스크린샷
----
- 첫번째 커밋
<img width="1840" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/0de6f1b2-623d-4098-96c3-e00ba4965d9e">
- 두번째 커밋
<img width="1840" alt="image" src="https://github.com/sgdevcamp2023/recycle/assets/102893954/f8e77118-0c42-49f4-a7a7-b47bd80f7721">


🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료