### PR TITLE
[Fe/#237] login 기능구현

### DIFF
--- a/fe/.env
+++ b/fe/.env
@@ -1,0 +1,1 @@
+VITE_API_URL = "https://virtserver.swaggerhub.com/jon53/Zzuag/1.0.0"

--- a/fe/src/components/block/modal/AskLoginModal.tsx
+++ b/fe/src/components/block/modal/AskLoginModal.tsx
@@ -90,11 +90,11 @@ const AskLoginModal = () => {
           <Logo src={logo} alt="zzaug main logo" />
           <p>계정이 없으신가요?</p>
           <Text
-            fontWeight='bold'
+            fontWeight="bold"
             style={{
               marginLeft: '0.25rem',
               cursor: 'pointer',
-              color: '#1eb649'
+              color: '#1eb649',
             }}
             onClick={() => move('signup')}
           >

--- a/fe/src/components/block/modal/LoginModal.tsx
+++ b/fe/src/components/block/modal/LoginModal.tsx
@@ -84,7 +84,6 @@ const LoginModal = () => {
         certification: email,
         password: password,
       });
-      move('');
     }
   };
 

--- a/fe/src/hooks/query/member/useLogin.ts
+++ b/fe/src/hooks/query/member/useLogin.ts
@@ -14,9 +14,10 @@ const useLogin = () => {
       const refresh = tokenData.refreshToken;
       console.log(access,refresh)
       if (access && refresh) {
-        console.log(access, refresh)
+        localStorage.setItem('access', access)
+        localStorage.setItem('refresh', refresh)
       } else {
-        console.error('조졌다')
+        console.error('토큰을 발급받지 못했습니다')
       }
     },
     onError: (err) => {

--- a/fe/src/hooks/query/member/useLogin.ts
+++ b/fe/src/hooks/query/member/useLogin.ts
@@ -1,7 +1,9 @@
 import memberApi from '@api/memberApi';
+import useMovePage from '@hooks/common/useMovePage';
 import { useMutation } from '@tanstack/react-query';
 
 const useLogin = () => {
+  const move = useMovePage();
   return useMutation({
     mutationFn: memberApi.login,
     onSuccess: (data) => {
@@ -16,6 +18,7 @@ const useLogin = () => {
       if (access && refresh) {
         localStorage.setItem('access', access)
         localStorage.setItem('refresh', refresh)
+        move('')
       } else {
         console.error('토큰을 발급받지 못했습니다')
       }

--- a/fe/src/hooks/query/member/useLogin.ts
+++ b/fe/src/hooks/query/member/useLogin.ts
@@ -4,17 +4,29 @@ import { useMutation } from '@tanstack/react-query';
 const useLogin = () => {
   return useMutation({
     mutationFn: memberApi.login,
-    onSuccess: () => {
+    onSuccess: (data) => {
       console.log('요청 성공');
+      console.log(data);
+
+      const tokenData = data?.data?.data
+
+      const access = tokenData.accessToken;
+      const refresh = tokenData.refreshToken;
+      console.log(access,refresh)
+      if (access && refresh) {
+        console.log(access, refresh)
+      } else {
+        console.error('조졌다')
+      }
     },
     onError: (err) => {
       console.error('에러 발생');
       console.log(err);
     },
-    onSettled: (data) => {
-      console.log('결과에 관계 없이 무언가 실행됨');
-      console.log(data);
-    },
+    // onSettled: (data) => {
+    //   console.log('결과에 관계 없이 무언가 실행됨');
+    //   console.log(data);
+    // },
   });
 };
 

--- a/fe/src/page/TestPageThree.tsx
+++ b/fe/src/page/TestPageThree.tsx
@@ -42,7 +42,7 @@ const TestPageThree = () => {
           fontSize="xs"
         /> */}
         {/* <RegisterEmail/> */}
-        <SendEmailModal/>
+        <SendEmailModal />
       </CenterModalBox>
     </>
   );

--- a/fe/vite.config.ts.timestamp-1706507854540-5f6efe600778.mjs
+++ b/fe/vite.config.ts.timestamp-1706507854540-5f6efe600778.mjs
@@ -1,53 +1,51 @@
 // vite.config.ts
-import { defineConfig } from "file:///Users/kmlee/recycle/fe/node_modules/vite/dist/node/index.js";
-import react from "file:///Users/kmlee/recycle/fe/node_modules/@vitejs/plugin-react/dist/index.mjs";
-import path from "path";
-import svgr from "file:///Users/kmlee/recycle/fe/node_modules/vite-plugin-svgr/dist/index.js";
-var __vite_injected_original_dirname = "/Users/kmlee/recycle/fe";
+import { defineConfig } from 'file:///Users/kmlee/recycle/fe/node_modules/vite/dist/node/index.js';
+import react from 'file:///Users/kmlee/recycle/fe/node_modules/@vitejs/plugin-react/dist/index.mjs';
+import path from 'path';
+import svgr from 'file:///Users/kmlee/recycle/fe/node_modules/vite-plugin-svgr/dist/index.js';
+var __vite_injected_original_dirname = '/Users/kmlee/recycle/fe';
 var vite_config_default = defineConfig({
   plugins: [react(), svgr()],
   resolve: {
     alias: [
       {
-        find: "@",
-        replacement: path.resolve(__vite_injected_original_dirname, "src")
+        find: '@',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src'),
       },
       {
-        find: "@page",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/page")
+        find: '@page',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/page'),
       },
       {
-        find: "@components",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/components")
+        find: '@components',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/components'),
       },
       {
-        find: "@api",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/api")
+        find: '@api',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/api'),
       },
       {
-        find: "@hook",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/hook")
+        find: '@hook',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/hook'),
       },
       {
-        find: "@styles",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/styles")
+        find: '@styles',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/styles'),
       },
       {
-        find: "@template",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/template")
+        find: '@template',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/template'),
       },
       {
-        find: "@store",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/store")
+        find: '@store',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/store'),
       },
       {
-        find: "@assets",
-        replacement: path.resolve(__vite_injected_original_dirname, "src/assets")
-      }
-    ]
-  }
+        find: '@assets',
+        replacement: path.resolve(__vite_injected_original_dirname, 'src/assets'),
+      },
+    ],
+  },
 });
-export {
-  vite_config_default as default
-};
+export { vite_config_default as default };
 //# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsidml0ZS5jb25maWcudHMiXSwKICAic291cmNlc0NvbnRlbnQiOiBbImNvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9kaXJuYW1lID0gXCIvVXNlcnMva21sZWUvcmVjeWNsZS9mZVwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL1VzZXJzL2ttbGVlL3JlY3ljbGUvZmUvdml0ZS5jb25maWcudHNcIjtjb25zdCBfX3ZpdGVfaW5qZWN0ZWRfb3JpZ2luYWxfaW1wb3J0X21ldGFfdXJsID0gXCJmaWxlOi8vL1VzZXJzL2ttbGVlL3JlY3ljbGUvZmUvdml0ZS5jb25maWcudHNcIjtpbXBvcnQgeyBkZWZpbmVDb25maWcgfSBmcm9tICd2aXRlJztcbmltcG9ydCByZWFjdCBmcm9tICdAdml0ZWpzL3BsdWdpbi1yZWFjdCc7XG5pbXBvcnQgcGF0aCBmcm9tICdwYXRoJztcbmltcG9ydCBzdmdyIGZyb20gJ3ZpdGUtcGx1Z2luLXN2Z3InO1xuXG5leHBvcnQgZGVmYXVsdCBkZWZpbmVDb25maWcoe1xuICBwbHVnaW5zOiBbcmVhY3QoKSwgc3ZncigpXSxcbiAgcmVzb2x2ZToge1xuICAgIGFsaWFzOiBbXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAcGFnZScsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3BhZ2UnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAY29tcG9uZW50cycsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL2NvbXBvbmVudHMnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAYXBpJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvYXBpJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQGhvb2snLFxuICAgICAgICByZXBsYWNlbWVudDogcGF0aC5yZXNvbHZlKF9fZGlybmFtZSwgJ3NyYy9ob29rJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQHN0eWxlcycsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3N0eWxlcycpLFxuICAgICAgfSxcbiAgICAgIHtcbiAgICAgICAgZmluZDogJ0B0ZW1wbGF0ZScsXG4gICAgICAgIHJlcGxhY2VtZW50OiBwYXRoLnJlc29sdmUoX19kaXJuYW1lLCAnc3JjL3RlbXBsYXRlJyksXG4gICAgICB9LFxuICAgICAge1xuICAgICAgICBmaW5kOiAnQHN0b3JlJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvc3RvcmUnKSxcbiAgICAgIH0sXG4gICAgICB7XG4gICAgICAgIGZpbmQ6ICdAYXNzZXRzJyxcbiAgICAgICAgcmVwbGFjZW1lbnQ6IHBhdGgucmVzb2x2ZShfX2Rpcm5hbWUsICdzcmMvYXNzZXRzJyksXG4gICAgICB9LFxuICAgIF0sXG4gIH0sXG59KTtcbiJdLAogICJtYXBwaW5ncyI6ICI7QUFBdVAsU0FBUyxvQkFBb0I7QUFDcFIsT0FBTyxXQUFXO0FBQ2xCLE9BQU8sVUFBVTtBQUNqQixPQUFPLFVBQVU7QUFIakIsSUFBTSxtQ0FBbUM7QUFLekMsSUFBTyxzQkFBUSxhQUFhO0FBQUEsRUFDMUIsU0FBUyxDQUFDLE1BQU0sR0FBRyxLQUFLLENBQUM7QUFBQSxFQUN6QixTQUFTO0FBQUEsSUFDUCxPQUFPO0FBQUEsTUFDTDtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsS0FBSztBQUFBLE1BQzVDO0FBQUEsTUFDQTtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsVUFBVTtBQUFBLE1BQ2pEO0FBQUEsTUFDQTtBQUFBLFFBQ0UsTUFBTTtBQUFBLFFBQ04sYUFBYSxLQUFLLFFBQVEsa0NBQVcsZ0JBQWdCO0FBQUEsTUFDdkQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxTQUFTO0FBQUEsTUFDaEQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxVQUFVO0FBQUEsTUFDakQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxZQUFZO0FBQUEsTUFDbkQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxjQUFjO0FBQUEsTUFDckQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxXQUFXO0FBQUEsTUFDbEQ7QUFBQSxNQUNBO0FBQUEsUUFDRSxNQUFNO0FBQUEsUUFDTixhQUFhLEtBQUssUUFBUSxrQ0FBVyxZQUFZO0FBQUEsTUFDbkQ7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUNGLENBQUM7IiwKICAibmFtZXMiOiBbXQp9Cg==


### PR DESCRIPTION
🎫 연관 티켓 
---
#237 

🙏 작업
----
- 연결된 로그인 api를 이용해 로그인 기능을 구현하였습니다.

💁‍♂️ 어떻게?
----
```js
const useLogin = () => {
  const move = useMovePage();
  return useMutation({
    mutationFn: memberApi.login,
    onSuccess: (data) => {
      console.log('요청 성공');
      console.log(data);

      const tokenData = data?.data?.data

      const access = tokenData.accessToken;
      const refresh = tokenData.refreshToken;
      console.log(access,refresh)
      if (access && refresh) {
        localStorage.setItem('access', access)
        localStorage.setItem('refresh', refresh)
        move('')
      } else {
        console.error('토큰을 발급받지 못했습니다')
      }
    },
    onError: (err) => {
      console.error('에러 발생');
      console.log(err);
    },
  });
};
```
- `useMutation`을 통해, 비동기 작업을 처리합니다.
  - 비동기 작업을 수행하는 함수를 지정하고, 해당 함수는 API 호출이나 다른 비동기 작업을 담당하며, 성공 또는 실패할 때의 결과를 반환합니다.
  - 해당 작업의 상태를 추적하고, 데이터를 캐시하고 자동으로 다시 렌더링되게 하여 UI를 쉽게 업데이트 할 수 있습니다.
  - onSuccess : 비동기 작업 성공시 실행되는 콜백 함수
  - onError : 비동기 작업 실패시 실행되는 콜백 함수
  - onSettled : 비동기 작업 성공, 실패 상관없이 실행되는 콜백함수
- 토큰값을 받아와서 `access`, `refresh`라는 변수에 담습니다.
- 해당 토큰들을 localStorage에 저장합니다.
- `access`, `refresh` 토큰이 모두 존재할 시에 `localStorage`에 저장, 기본 페이지로 이동합니다.
  - 실패시엔 토큰을 발급받지 못했음을 출력합니다.
  - 에러가 발생시엔 에러발생을 출력합니다. 

🙈 PR 참고 사항
----
### 로직 순서 정리
- 로그인 clikc
- access, refresh token 발행
- 발행한 토큰을 꺼내서 console에 확인
- localStorage에 넣어주기
- '/'(기본)페이지로 이동

📸 스크린샷
----
- 성공시 콘솔창 (토큰을 받아오는 것 확인)
![image](https://github.com/sgdevcamp2023/recycle/assets/102893954/f5e8f374-f8d5-42a7-b4a8-c8ece5e83557)

- 네트워크 탭
![image](https://github.com/sgdevcamp2023/recycle/assets/102893954/d7291902-731a-498a-b6a9-0769563b6bd8)

- localStorage (토큰을 담음)
![image](https://github.com/sgdevcamp2023/recycle/assets/102893954/36b459ec-a1e3-4280-8f1d-1872ab64ee24)



🤖 테스트 체크리스트
----
- [x] 체크 미완료
- [ ] 체크 완료