### PR TITLE
[Be/#249] Feat: 추가 멤버 API 중 시큐리티 필터 제외 주소

### DIFF
--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION.java
@@ -26,12 +26,11 @@ class SearchMemberUseCaseTest_NOT_EXIST_CERTIFICATION extends AbstractUseCaseTes
 				SearchMemberUseCaseRequest.builder().certification("notExist").build();
 
 		// When
-		SourceNotFoundException exception = Assertions.assertThrows(
-			SourceNotFoundException.class, () -> searchMemberUseCase.execute(request)
-		);
+		SourceNotFoundException exception =
+				Assertions.assertThrows(
+						SourceNotFoundException.class, () -> searchMemberUseCase.execute(request));
 
 		// Then
-		org.assertj.core.api.Assertions.assertThat(exception.getMessage())
-			.contains("Certification");
+		org.assertj.core.api.Assertions.assertThat(exception.getMessage()).contains("Certification");
 	}
 }

--- a/be/security/src/main/java/com/zzaug/security/config/WebSecurityConfig.java
+++ b/be/security/src/main/java/com/zzaug/security/config/WebSecurityConfig.java
@@ -101,7 +101,11 @@ public class WebSecurityConfig {
 								"/openapi3.yaml",
 								"/reports/**",
 								"/api/v1/members/check")
-						.antMatchers(HttpMethod.POST, "/api/v1/members");
+						.antMatchers(
+								HttpMethod.POST,
+								"/api/v1/members",
+								"/api/v1/members/token",
+								"/api/v1/members/login");
 	}
 
 	@Bean
@@ -119,7 +123,11 @@ public class WebSecurityConfig {
 								"/openapi3.yaml",
 								"/reports/**",
 								"/api/v1/members/check")
-						.antMatchers(HttpMethod.POST, "/api/v1/members");
+						.antMatchers(
+								HttpMethod.POST,
+								"/api/v1/members",
+								"/api/v1/members/token",
+								"/api/v1/members/login");
 	}
 
 	@Bean


### PR DESCRIPTION
🎫 연관 티켓 
---
#249

🙏 작업
----
- 시큐리티 필터를 거치지 않을 `Member` API 주소를 정의합니다.

💁‍♂️ 어떻게?
----

🙈 PR 참고 사항
----
추후 `be/dev`로 base를 교체하고 머지하여야 합니다.

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료