### PR TITLE
[Be/#250] Refactor: controller

### DIFF
--- a/be/member-api/src/main/java/com/zzaug/member/domain/dto/member/MemberAuthToken.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/dto/member/MemberAuthToken.java
@@ -17,4 +17,21 @@ public class MemberAuthToken {
 
 	private String accessToken;
 	private String refreshToken;
+
+	public AccessTokenResponse toResponse() {
+		return new AccessTokenResponse(this.accessToken);
+	}
+
+	@Getter
+	@ToString
+	@EqualsAndHashCode
+	@NoArgsConstructor
+	@Builder(toBuilder = true)
+	public static class AccessTokenResponse {
+		private String accessToken;
+
+		public AccessTokenResponse(String accessToken) {
+			this.accessToken = accessToken;
+		}
+	}
 }

--- a/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberCheckController.java
+++ b/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberCheckController.java
@@ -92,7 +92,7 @@ public class MemberCheckController {
 						.nonce(request.getNonce())
 						.build();
 		CheckEmailAuthUseCaseResponse response =
-				CheckEmailAuthUseCaseResponse.builder().authentication(true).tryCount(3L).build();
+				CheckEmailAuthUseCaseResponse.builder().authentication(true).tryCount(2L).build();
 		//		CheckEmailAuthUseCaseResponse response = checkEmailAuthUseCase.execute(useCaseRequest);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.SUCCESS);
 	}

--- a/be/member-api/src/main/java/com/zzaug/member/web/dto/member/LoginRequest.java
+++ b/be/member-api/src/main/java/com/zzaug/member/web/dto/member/LoginRequest.java
@@ -1,5 +1,7 @@
 package com.zzaug.member.web.dto.member;
 
+import com.zzaug.member.web.dto.validator.Certification;
+import com.zzaug.member.web.dto.validator.Password;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -15,6 +17,6 @@ import lombok.ToString;
 @Builder(toBuilder = true)
 public class LoginRequest {
 
-	private String certification;
-	private String password;
+	@Certification private String certification;
+	@Password private String password;
 }

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/repository/UMockAuthenticationDao.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/repository/UMockAuthenticationDao.java
@@ -30,7 +30,7 @@ public class UMockAuthenticationDao implements AuthenticationDao, ApplicationCon
 
 	public static final Long AUTHENTICATION_ID = 1L;
 	public static final Long MEMBER_ID = 1L;
-	public static final String CERTIFICATION = "sample@email.com";
+	public static final String CERTIFICATION = "sample";
 	public static final String PASSWORD_SOURCE = "123@abc";
 
 	private List<String> activeProfiles;

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/repository/UMockEmailAuthDao.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/repository/UMockEmailAuthDao.java
@@ -19,6 +19,7 @@ import org.springframework.context.annotation.Profile;
 @TestComponent
 public class UMockEmailAuthDao implements EmailAuthDao {
 
+	public static String EMAIL = "sample@email.com";
 	public static String CODE = "thisiscode";
 
 	@Override

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT.java
@@ -1,13 +1,16 @@
 package com.zzaug.member.domain.usecase.member;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import com.zzaug.member.MemberApp;
 import com.zzaug.member.domain.dto.member.CheckEmailAuthUseCaseRequest;
+import com.zzaug.member.domain.dto.member.CheckEmailAuthUseCaseResponse;
 import com.zzaug.member.domain.usecase.AbstractUseCaseTest;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockEmailAuthDao;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockEmailAuthLogDao;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockExternalContactDao;
 import com.zzaug.member.domain.usecase.config.mock.service.UMockMemberSourceQuery;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -28,7 +31,7 @@ class CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 
 	Long memberId = 1L;
 	String code = UMockEmailAuthDao.CODE;
-	String email = "sample@email.com";
+	String email = UMockEmailAuthDao.EMAIL;
 	String nonce = "nonce";
 	final CheckEmailAuthUseCaseRequest request =
 			CheckEmailAuthUseCaseRequest.builder()
@@ -43,8 +46,11 @@ class CheckEmailAuthUseCaseTest_OVER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 		// Given
 
 		// When
-		Assertions.assertThatThrownBy(() -> checkEmailAuthUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("request try count is over");
+		CheckEmailAuthUseCaseResponse response = checkEmailAuthUseCase.execute(request);
+
+		// Then
+		org.junit.jupiter.api.Assertions.assertAll(
+				() -> assertFalse(response.getAuthentication()),
+				() -> assertThat(response.getTryCount()).isEqualTo(UMockEmailAuthLogDao.MAX_TRY_COUNT));
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT.java
@@ -33,7 +33,7 @@ class CheckEmailAuthUseCaseTest_UNDER_MAX_TRYCOUNT extends AbstractUseCaseTest {
 
 	Long memberId = 1L;
 	String code = UMockEmailAuthDao.CODE;
-	String email = "sample@email.com";
+	String email = UMockEmailAuthDao.EMAIL;
 	String nonce = "nonce";
 	final CheckEmailAuthUseCaseRequest request =
 			CheckEmailAuthUseCaseRequest.builder()

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/LoginUseCaseTest.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/LoginUseCaseTest.java
@@ -3,6 +3,7 @@ package com.zzaug.member.domain.usecase.member;
 import com.zzaug.member.MemberApp;
 import com.zzaug.member.domain.dto.member.LoginUseCaseRequest;
 import com.zzaug.member.domain.dto.member.MemberAuthToken;
+import com.zzaug.member.domain.exception.PasswordNotMatchException;
 import com.zzaug.member.domain.usecase.AbstractUseCaseTest;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockAuthenticationDao;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockExternalContactDao;
@@ -53,7 +54,6 @@ class LoginUseCaseTest extends AbstractUseCaseTest {
 
 		// When
 		org.assertj.core.api.Assertions.assertThatThrownBy(() -> loginUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("비밀번호가 일치하지 않습니다.");
+				.isInstanceOf(PasswordNotMatchException.class);
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/RenewalTokenUseCaseTest.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/RenewalTokenUseCaseTest.java
@@ -29,6 +29,7 @@ class RenewalTokenUseCaseTest extends AbstractUseCaseTest {
 		RenewalTokenUseCaseRequest request =
 				RenewalTokenUseCaseRequest.builder()
 						.refreshToken(UMockBlackTokenAuthDao.SAMPLE_TOKEN)
+						.accessToken(UMockBlackTokenAuthDao.SAMPLE_TOKEN)
 						.build();
 
 		MemberAuthToken response = renewalTokenUseCase.execute(request);

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCaseTest.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCaseTest.java
@@ -2,6 +2,7 @@ package com.zzaug.member.domain.usecase.member;
 
 import com.zzaug.member.MemberApp;
 import com.zzaug.member.domain.dto.member.UpdateMemberUseCaseRequest;
+import com.zzaug.member.domain.exception.PasswordNotMatchException;
 import com.zzaug.member.domain.usecase.AbstractUseCaseTest;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockAuthenticationDao;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockMemberSourceDao;
@@ -22,7 +23,7 @@ class UpdateMemberUseCaseTest extends AbstractUseCaseTest {
 		UpdateMemberUseCaseRequest request =
 				UpdateMemberUseCaseRequest.builder()
 						.memberId(UMockMemberSourceDao.MEMBER_ID)
-						.certification("edit@email.com")
+						.certification(UMockAuthenticationDao.CERTIFICATION)
 						.password(UMockAuthenticationDao.PASSWORD_SOURCE)
 						.build();
 
@@ -39,7 +40,6 @@ class UpdateMemberUseCaseTest extends AbstractUseCaseTest {
 						.build();
 
 		Assertions.assertThatThrownBy(() -> updateMemberUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("비밀번호가 일치하지 않습니다.");
+				.isInstanceOf(PasswordNotMatchException.class);
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCaseTest_EXIST_CERTIFICATION.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCaseTest_EXIST_CERTIFICATION.java
@@ -2,6 +2,7 @@ package com.zzaug.member.domain.usecase.member;
 
 import com.zzaug.member.MemberApp;
 import com.zzaug.member.domain.dto.member.UpdateMemberUseCaseRequest;
+import com.zzaug.member.domain.exception.ExistSourceException;
 import com.zzaug.member.domain.usecase.AbstractUseCaseTest;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockAuthenticationDao;
 import com.zzaug.member.domain.usecase.config.mock.repository.UMockMemberSourceDao;
@@ -24,12 +25,11 @@ class UpdateMemberUseCaseTest_EXIST_CERTIFICATION extends AbstractUseCaseTest {
 		UpdateMemberUseCaseRequest request =
 				UpdateMemberUseCaseRequest.builder()
 						.memberId(UMockMemberSourceDao.MEMBER_ID)
-						.certification("edit@email.com")
+						.certification(UMockAuthenticationDao.CERTIFICATION + "edit")
 						.password(UMockAuthenticationDao.PASSWORD_SOURCE)
 						.build();
 
 		Assertions.assertThatThrownBy(() -> updateMemberUseCase.execute(request))
-				.isInstanceOf(IllegalArgumentException.class)
-				.hasMessageContaining("이미 존재하는 아이디입니다.");
+				.isInstanceOf(ExistSourceException.class);
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/description/Description.java
+++ b/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/description/Description.java
@@ -4,6 +4,7 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 
 import com.epages.restdocs.apispec.HeaderDescriptorWithType;
+import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -80,11 +81,16 @@ public class Description {
 				.description("Bearer 어세스 토큰");
 	}
 
-	public static HeaderDescriptorWithType refererHeader() {
-		return headerWithName("Referer").description("이전 주소 정보");
+	public static HeaderDescriptorWithType xZzaugIdHeader() {
+		return headerWithName("X-ZZAUG-ID")
+				.description("요청 추적을 위한 uuid")
+				.defaultValue(UUID.randomUUID());
 	}
 
-	public static HeaderDescriptorWithType xZzaugIdHeader() {
-		return headerWithName("X-ZZAUG-ID").description("요청 추적을 위한 uuid");
+	public static HeaderDescriptorWithType setCookieHeader() {
+		return headerWithName("Set-Cookie")
+				.defaultValue(
+						"refreshToken=refreshToken; Path=/; HttpOnly; Domain=swaggerhub.com; SameSite=Lax; Secure")
+				.description("리프레시 토큰 쿠키");
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/description/Description.java
+++ b/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/description/Description.java
@@ -19,12 +19,19 @@ public class Description {
 		return fieldWithPath("message").type(JsonFieldType.STRING).description("성공");
 	}
 
+	private static FieldDescriptor getTimeStampDescriptor() {
+		return fieldWithPath("timestamp").type(JsonFieldType.STRING).description("응답 시간");
+	}
+
 	public static FieldDescriptor[] success(FieldDescriptor[] data) {
-		return ArrayUtils.addAll(data, getSuccessMessageDescriptor(), getSuccessCodeDescriptor());
+		return ArrayUtils.addAll(
+				data, getSuccessMessageDescriptor(), getSuccessCodeDescriptor(), getTimeStampDescriptor());
 	}
 
 	public static FieldDescriptor[] success() {
-		return new FieldDescriptor[] {getSuccessMessageDescriptor(), getSuccessCodeDescriptor()};
+		return new FieldDescriptor[] {
+			getSuccessMessageDescriptor(), getSuccessCodeDescriptor(), getTimeStampDescriptor()
+		};
 	}
 
 	private static FieldDescriptor getCreateCodeDescriptor() {
@@ -52,19 +59,27 @@ public class Description {
 	}
 
 	public static FieldDescriptor[] created() {
-		return new FieldDescriptor[] {getCreateCodeDescriptor(), getCreateMessageDescriptor()};
+		return new FieldDescriptor[] {
+			getCreateCodeDescriptor(), getCreateMessageDescriptor(), getTimeStampDescriptor()
+		};
 	}
 
 	public static FieldDescriptor[] fail() {
-		return new FieldDescriptor[] {getFailCodeDescriptor(), getFailMessageDescriptor()};
+		return new FieldDescriptor[] {
+			getFailCodeDescriptor(), getFailMessageDescriptor(), getTimeStampDescriptor()
+		};
 	}
 
 	public static FieldDescriptor[] modified() {
-		return new FieldDescriptor[] {getModifiedCodeDescriptor(), getModifiedMessageDescriptor()};
+		return new FieldDescriptor[] {
+			getModifiedCodeDescriptor(), getModifiedMessageDescriptor(), getTimeStampDescriptor()
+		};
 	}
 
 	public static FieldDescriptor[] deleted() {
-		return new FieldDescriptor[] {getDeletedCodeDescriptor(), getDeletedMessageDescriptor()};
+		return new FieldDescriptor[] {
+			getDeletedCodeDescriptor(), getDeletedMessageDescriptor(), getTimeStampDescriptor()
+		};
 	}
 
 	private static FieldDescriptor getFailCodeDescriptor() {

--- a/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/member/MemberCheckControllerTest.java
+++ b/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/member/MemberCheckControllerTest.java
@@ -14,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.zzaug.member.MemberApp;
 import com.zzaug.member.web.controller.v1.description.Description;
 import com.zzaug.member.web.dto.member.CheckEmailAuthRequest;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +43,13 @@ class MemberCheckControllerTest {
 	private static final String PUT_BASE_URL_DNAME = "[PUT] " + BASE_URL;
 	private static final String DELETE_BASE_URL_DNAME = "[DELETE] " + BASE_URL;
 
+	private static final String X_ZZAUG_ID = "X-ZZAUG-ID";
+	private static final String CERTIFICATION = "certification";
+	private static final String PASSWORD = "password@123";
+	private static final String EMAIL = "sample@email.com";
+	private static final String NONCE = "nonce";
+	private static final String CODE = "code";
+
 	@Test
 	@DisplayName(GET_BASE_URL_DNAME)
 	void check() throws Exception {
@@ -51,9 +59,8 @@ class MemberCheckControllerTest {
 				.perform(
 						get(BASE_URL, 0)
 								.contentType(MediaType.APPLICATION_JSON)
-								.param("certification", "sample")
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.param("certification", CERTIFICATION)
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -64,10 +71,7 @@ class MemberCheckControllerTest {
 												.description("아이디 중복 검사를 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("CheckMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.requestParameters(
 														parameterWithName("certification").description("증명(아이디)"))
 												.responseSchema(Schema.schema("CheckMemberResponse"))
@@ -93,10 +97,9 @@ class MemberCheckControllerTest {
 				.perform(
 						get(BASE_URL + "/email", 0)
 								.contentType(MediaType.APPLICATION_JSON)
-								.param("email", "{email}")
-								.param("nonce", "{nonce}")
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.param("email", EMAIL)
+								.param("nonce", NONCE)
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -107,10 +110,7 @@ class MemberCheckControllerTest {
 												.description("이메일 인증 요청을 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("EmailAuthRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.requestParameters(
 														parameterWithName("email").description("이메일"),
 														parameterWithName("nonce").description("인증번호"))
@@ -133,7 +133,7 @@ class MemberCheckControllerTest {
 	void checkEmailAuth() throws Exception {
 		// set service mock
 		CheckEmailAuthRequest request =
-				CheckEmailAuthRequest.builder().code("code").email("email").nonce("nonce").build();
+				CheckEmailAuthRequest.builder().code(CODE).email(EMAIL).nonce(NONCE).build();
 		String content = objectMapper.writeValueAsString(request);
 
 		mockMvc
@@ -141,8 +141,7 @@ class MemberCheckControllerTest {
 						post(BASE_URL + "/email", 0)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content(content)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -153,10 +152,7 @@ class MemberCheckControllerTest {
 												.description("이메일 인증 번호 확인합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("CheckEmailAuthRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("CheckEmailAuthResponse"))
 												.responseFields(
 														Description.success(

--- a/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/member/MemberControllerTest.java
+++ b/be/member-api/src/test/java/com/zzaug/member/web/controller/v1/member/MemberControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.epages.restdocs.apispec.HeaderDescriptorWithType;
 import com.epages.restdocs.apispec.ResourceSnippetParameters;
 import com.epages.restdocs.apispec.Schema;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -17,6 +18,7 @@ import com.zzaug.member.web.controller.v1.description.Description;
 import com.zzaug.member.web.dto.member.LoginRequest;
 import com.zzaug.member.web.dto.member.MemberSaveRequest;
 import com.zzaug.member.web.dto.member.MemberUpdateRequest;
+import java.util.UUID;
 import javax.servlet.http.Cookie;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,15 +49,16 @@ class MemberControllerTest {
 	private static final String PUT_BASE_URL_DNAME = "[PUT] " + BASE_URL;
 	private static final String DELETE_BASE_URL_DNAME = "[DELETE] " + BASE_URL;
 
+	private static final String X_ZZAUG_ID = "X-ZZAUG-ID";
+	private static final String CERTIFICATION = "certification";
+	private static final String PASSWORD = "password@123";
+
 	@Test
 	@DisplayName(POST_BASE_URL_DNAME)
 	void save() throws Exception {
 		// set service mock
 		MemberSaveRequest request =
-				MemberSaveRequest.builder()
-						.certification("certification123")
-						.password("password@123")
-						.build();
+				MemberSaveRequest.builder().certification(CERTIFICATION).password(PASSWORD).build();
 
 		String content = objectMapper.writeValueAsString(request);
 
@@ -64,8 +67,7 @@ class MemberControllerTest {
 						post(BASE_URL, 0)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content(content)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -76,10 +78,7 @@ class MemberControllerTest {
 												.description("회원가입을 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("SaveMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("SaveMemberResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -90,7 +89,7 @@ class MemberControllerTest {
 	void update() throws Exception {
 		// set service mock
 		MemberUpdateRequest request =
-				MemberUpdateRequest.builder().certification("certification").password("password").build();
+				MemberUpdateRequest.builder().certification(CERTIFICATION).password(PASSWORD).build();
 
 		String content = objectMapper.writeValueAsString(request);
 		mockMvc
@@ -98,8 +97,7 @@ class MemberControllerTest {
 						put(BASE_URL, 0)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content(content)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -110,10 +108,7 @@ class MemberControllerTest {
 												.description("회원정보를 수정합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("UpdateMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("UpdateMemberResponse"))
 												.responseFields(Description.modified())
 												.build())));
@@ -128,8 +123,7 @@ class MemberControllerTest {
 				.perform(
 						RestDocumentationRequestBuilders.delete(BASE_URL, 0)
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -140,10 +134,7 @@ class MemberControllerTest {
 												.description("회원 탈퇴를 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("UpdateMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("UpdateMemberResponse"))
 												.responseFields(Description.deleted())
 												.build())));
@@ -154,7 +145,7 @@ class MemberControllerTest {
 	void login() throws Exception {
 		// set service mock
 		LoginRequest request =
-				LoginRequest.builder().certification("certification").password("password").build();
+				LoginRequest.builder().certification(CERTIFICATION).password(PASSWORD).build();
 
 		String content = objectMapper.writeValueAsString(request);
 
@@ -163,8 +154,7 @@ class MemberControllerTest {
 						post(BASE_URL + "/login", 0)
 								.contentType(MediaType.APPLICATION_JSON)
 								.content(content)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -175,10 +165,7 @@ class MemberControllerTest {
 												.description("로그인을 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("LoginMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("LoginMemberResponse"))
 												.responseFields(
 														Description.success(
@@ -189,10 +176,9 @@ class MemberControllerTest {
 																	fieldWithPath("data.accessToken")
 																			.type(JsonFieldType.STRING)
 																			.description("어세스 토큰"),
-																	fieldWithPath("data.refreshToken")
-																			.type(JsonFieldType.STRING)
-																			.description("리프레시 토큰"),
 																}))
+												.responseHeaders(
+														new HeaderDescriptorWithType[] {Description.setCookieHeader()})
 												.build())));
 	}
 
@@ -207,8 +193,7 @@ class MemberControllerTest {
 				.perform(
 						post(BASE_URL + "/logout", 0)
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
 								.cookie(cookie))
 				.andExpect(status().is2xxSuccessful())
@@ -220,10 +205,7 @@ class MemberControllerTest {
 												.description("로그아웃을 진행합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("LogoutMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("LogoutMemberResponse"))
 												.responseFields(Description.success())
 												.build())));
@@ -238,8 +220,7 @@ class MemberControllerTest {
 				.perform(
 						get(BASE_URL + "/{id}", 1)
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -250,10 +231,7 @@ class MemberControllerTest {
 												.description("멤버 정보를 조회합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("ReadMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.pathParameters(parameterWithName("id").description("조회할 멤버의 아이디"))
 												.responseSchema(Schema.schema("ReadMemberResponse"))
 												.responseFields(
@@ -285,8 +263,7 @@ class MemberControllerTest {
 						get(BASE_URL, 0)
 								.contentType(MediaType.APPLICATION_JSON)
 								.queryParam("certification", "{certification}")
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken"))
 				.andExpect(status().is2xxSuccessful())
 				.andDo(
@@ -299,10 +276,7 @@ class MemberControllerTest {
 														parameterWithName("certification").description("증명(아이디)").optional())
 												.tag(TAG)
 												.requestSchema(Schema.schema("SearchMemberRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("SearchMemberResponse"))
 												.responseFields(
 														Description.success(
@@ -334,8 +308,7 @@ class MemberControllerTest {
 				.perform(
 						post(BASE_URL + "/token", 0)
 								.contentType(MediaType.APPLICATION_JSON)
-								.header("X-ZZAUG-ID", "X-ZZAUG-ID")
-								.header(HttpHeaders.REFERER, "referer")
+								.header(X_ZZAUG_ID, UUID.randomUUID())
 								.header(HttpHeaders.AUTHORIZATION, "Bearer accessToken")
 								.cookie(refreshTokenCookie))
 				.andExpect(status().is2xxSuccessful())
@@ -347,10 +320,7 @@ class MemberControllerTest {
 												.description("토큰을 갱신합니다.")
 												.tag(TAG)
 												.requestSchema(Schema.schema("MemberTokenRequest"))
-												.requestHeaders(
-														Description.authHeader(),
-														Description.xZzaugIdHeader(),
-														Description.refererHeader())
+												.requestHeaders(Description.authHeader(), Description.xZzaugIdHeader())
 												.responseSchema(Schema.schema("MemberTokenResponse"))
 												.responseFields(
 														Description.success(
@@ -361,10 +331,9 @@ class MemberControllerTest {
 																	fieldWithPath("data.accessToken")
 																			.type(JsonFieldType.STRING)
 																			.description("어세스 토큰"),
-																	fieldWithPath("data.refreshToken")
-																			.type(JsonFieldType.STRING)
-																			.description("리프레시 토큰"),
 																}))
+												.responseHeaders(
+														new HeaderDescriptorWithType[] {Description.setCookieHeader()})
 												.build())));
 	}
 }

--- a/be/security/src/main/java/com/zzaug/security/config/WebSecurityConfig.java
+++ b/be/security/src/main/java/com/zzaug/security/config/WebSecurityConfig.java
@@ -101,7 +101,11 @@ public class WebSecurityConfig {
 								"/openapi3.yaml",
 								"/reports/**",
 								"/api/v1/members/check")
-						.antMatchers(HttpMethod.POST, "/api/v1/members");
+						.antMatchers(
+								HttpMethod.POST,
+								"/api/v1/members",
+								"/api/v1/members/token",
+								"/api/v1/members/login");
 	}
 
 	@Bean
@@ -119,7 +123,11 @@ public class WebSecurityConfig {
 								"/openapi3.yaml",
 								"/reports/**",
 								"/api/v1/members/check")
-						.antMatchers(HttpMethod.POST, "/api/v1/members");
+						.antMatchers(
+								HttpMethod.POST,
+								"/api/v1/members",
+								"/api/v1/members/token",
+								"/api/v1/members/login");
 	}
 
 	@Bean


### PR DESCRIPTION
🎫 연관 티켓 
---
#250

🙏 작업
----
- 이전 기능 구현간 컨트롤러에서 놓였던 것들을 수정하였습니다.

💁‍♂️ 어떻게?
----
`LoginRequest` 객체에 대한 검증이 수행되지 않아 검증을 추가하였습니다.

`MemberAuthToken`을 그대로 반환하였을 때 쿠키로 반환되어야 할 `refreshToken`까지 반환되는 상황이 발생하여 응답 객체를 추가로 만들어 주었습니다.

유즈케이스 테스트 중에서는
검증 로직 추가로 검증을 통과하지 못하는 테스트 케이스,
반환 예외 변경으로 통과하지 못하는 테스트 케이스를 수정하였습니다. (이전 PR에서 수정한 것 같은데 반영이 안되어있네요..)

컨트롤러 테스트의 경우는 변경된 요청과 응답 값에 맞도록 수정하여 주었습니다.

🙈 PR 참고 사항
----
추후 `be/dev`로 base를 교체하고 머지하여야 합니다.

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료