### PR TITLE
[BE/#312] Fix: timestamp 직렬화 문제

### DIFF
--- a/be/web/src/main/java/com/zzaug/web/support/ApiResponse.java
+++ b/be/web/src/main/java/com/zzaug/web/support/ApiResponse.java
@@ -1,5 +1,10 @@
 package com.zzaug.web.support;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import lombok.Getter;
@@ -22,6 +27,10 @@ public class ApiResponse<B> extends ResponseEntity<B> {
 
 		private String code;
 		private String message;
+
+		@JsonSerialize(using = LocalDateTimeSerializer.class)
+		@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
 		private LocalDateTime timestamp;
 
 		public FailureBody(String code, String message) {
@@ -41,6 +50,10 @@ public class ApiResponse<B> extends ResponseEntity<B> {
 		private D data;
 		private String message;
 		private String code;
+
+		@JsonSerialize(using = LocalDateTimeSerializer.class)
+		@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
 		private LocalDateTime timestamp;
 
 		public SuccessBody(D data, String message, String code) {
@@ -55,6 +68,10 @@ public class ApiResponse<B> extends ResponseEntity<B> {
 	public static class Success implements Serializable {
 		private String message;
 		private String code;
+
+		@JsonSerialize(using = LocalDateTimeSerializer.class)
+		@JsonDeserialize(using = LocalDateTimeDeserializer.class)
+		@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
 		private LocalDateTime timestamp;
 
 		public Success(String message, String code) {


### PR DESCRIPTION
🎫 연관 티켓 
---
#312

🙏 작업
----
- ApiResponse의 timestamp의 LocalDateTime 직렬화 되지 않는 문제 해결 

💁‍♂️ 어떻게?
----
Java 8 에는 LocalDataTime을 역직렬화하지 못해서 생기는 문제가 있다고 합니다.

jackson-datatype-jsr310 의존성은 security에 존재합니다.

해당 의존성을 사용해 LocalDateTime 타입의 값에 @JsonSerialize, @JsonDeserialize를 설정해 주었습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료