### PR TITLE
[Be/#304] Feat: active users

### DIFF
--- a/be/member-api/src/main/java/com/zzaug/member/config/MemberSessionConfig.java
+++ b/be/member-api/src/main/java/com/zzaug/member/config/MemberSessionConfig.java
@@ -2,13 +2,16 @@ package com.zzaug.member.config;
 
 import static com.zzaug.member.config.MemberRedisConfig.REDIS_CONNECTION_FACTORY_NAME;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializer;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.data.redis.config.annotation.SpringSessionRedisConnectionFactory;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.web.http.CookieHttpSessionIdResolver;
@@ -17,7 +20,7 @@ import org.springframework.session.web.http.DefaultCookieSerializer;
 import org.springframework.session.web.http.HttpSessionIdResolver;
 
 @Configuration
-@EnableRedisHttpSession(redisNamespace = "zzuag:session")
+@EnableRedisHttpSession
 public class MemberSessionConfig {
 	public static final String SESSION_BEAN_NAME_PREFIX =
 			MemberAppConfig.BEAN_NAME_PREFIX + "Session";
@@ -27,7 +30,10 @@ public class MemberSessionConfig {
 			SESSION_BEAN_NAME_PREFIX + "CookieSerializer";
 	private static final String SPRING_SESSION_DEFAULT_REDIS_SERIALIZER_BEAN_NAME =
 			SESSION_BEAN_NAME_PREFIX + "SpringSessionDefaultRedisSerializer";
+	private static final String MEMBER_SESSION_REPOSITORY_BEAN_NAME =
+			SESSION_BEAN_NAME_PREFIX + "Repository";
 
+	public static final String SESSION_NAME_SPACE = "zzuag:session";
 	private static final String COOKIE_NAME = "JSESSIONID";
 	private static final Boolean HTTP_ONLY = true;
 	private static final Boolean SECURE = true;
@@ -37,6 +43,9 @@ public class MemberSessionConfig {
 
 	@Value("${cookie.path}")
 	private String path;
+
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessExpireTime;
 
 	@Bean(name = HTTP_SESSION_ID_RESOLVER_BEAN_NAME)
 	public HttpSessionIdResolver cookieHttpSessionIdResolver() {
@@ -66,5 +75,15 @@ public class MemberSessionConfig {
 	public RedisConnectionFactory springSessionRedisConnectionFactory(
 			@Qualifier(REDIS_CONNECTION_FACTORY_NAME) RedisConnectionFactory redisConnectionFactory) {
 		return redisConnectionFactory;
+	}
+
+	@Primary
+	@Bean(name = MEMBER_SESSION_REPOSITORY_BEAN_NAME)
+	public RedisIndexedSessionRepository sessionRepository(
+			@Qualifier("sessionRepository") RedisIndexedSessionRepository sessionRepository) {
+		sessionRepository.setDefaultMaxInactiveInterval(
+				(int) Duration.ofMillis(accessExpireTime).getSeconds());
+		sessionRepository.setRedisKeyNamespace(SESSION_NAME_SPACE);
+		return sessionRepository;
 	}
 }

--- a/be/member-api/src/main/java/com/zzaug/member/domain/dto/member/MemberAuthToken.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/dto/member/MemberAuthToken.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 @Builder(toBuilder = true)
 public class MemberAuthToken {
 
+	private Long memberId;
 	private String accessToken;
 	private String refreshToken;
 

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollBlackTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollBlackTokenCacheServiceImpl.java
@@ -19,8 +19,8 @@ public class EnrollBlackTokenCacheServiceImpl implements EnrollTokenCacheService
 
 	@Override
 	@SecurityTransactional
-	public void execute(String token) {
-		blackAuthTokenHashRepository.save(BlackAuthTokenHash.builder().token(token).build());
+	public void execute(String token, Long ttl) {
+		blackAuthTokenHashRepository.save(BlackAuthTokenHash.builder().token(token).ttl(ttl).build());
 	}
 
 	@Override

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollTokenCacheService.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollTokenCacheService.java
@@ -2,7 +2,7 @@ package com.zzaug.member.domain.external.security.auth;
 
 public interface EnrollTokenCacheService {
 
-	void execute(String token);
+	void execute(String token, Long ttl);
 
 	void execute(String accessToken, String refreshToken);
 }

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteAccessTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteAccessTokenCacheServiceImpl.java
@@ -5,7 +5,6 @@ import com.zzaug.security.redis.auth.WhiteAuthTokenHash;
 import com.zzaug.security.redis.auth.WhiteAuthTokenHashRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -15,16 +14,12 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EnrollWhiteAccessTokenCacheServiceImpl implements EnrollTokenCacheService {
 
-	@Value("${security.jwt.token.validtime.access}")
-	private Long accessTokenValidTime;
-
 	private final WhiteAuthTokenHashRepository whiteAuthTokenHashRepository;
 
 	@Override
 	@SecurityTransactional
-	public void execute(String token) {
-		whiteAuthTokenHashRepository.save(
-				WhiteAuthTokenHash.builder().token(token).ttl(accessTokenValidTime).build());
+	public void execute(String token, Long ttl) {
+		whiteAuthTokenHashRepository.save(WhiteAuthTokenHash.builder().token(token).ttl(ttl).build());
 	}
 
 	@Override

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteAccessTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteAccessTokenCacheServiceImpl.java
@@ -1,0 +1,34 @@
+package com.zzaug.member.domain.external.security.auth;
+
+import com.zzaug.security.persistence.transaction.SecurityTransactional;
+import com.zzaug.security.redis.auth.WhiteAuthTokenHash;
+import com.zzaug.security.redis.auth.WhiteAuthTokenHashRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Profile("!usecase-test")
+@Component
+@RequiredArgsConstructor
+public class EnrollWhiteAccessTokenCacheServiceImpl implements EnrollTokenCacheService {
+
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessTokenValidTime;
+
+	private final WhiteAuthTokenHashRepository whiteAuthTokenHashRepository;
+
+	@Override
+	@SecurityTransactional
+	public void execute(String token) {
+		whiteAuthTokenHashRepository.save(
+				WhiteAuthTokenHash.builder().token(token).ttl(accessTokenValidTime).build());
+	}
+
+	@Override
+	public void execute(String accessToken, String refreshToken) {
+		throw new RuntimeException("Not Supported Exception");
+	}
+}

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/EnrollWhiteTokenCacheServiceImpl.java
@@ -6,6 +6,7 @@ import com.zzaug.security.redis.auth.WhiteAuthTokenHashRepository;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
@@ -15,19 +16,25 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class EnrollWhiteTokenCacheServiceImpl implements EnrollTokenCacheService {
 
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessTokenValidTime;
+
+	@Value("${security.jwt.token.validtime.refresh}")
+	private Long refreshTokenValidTime;
+
 	private final WhiteAuthTokenHashRepository whiteAuthTokenHashRepository;
 
 	@Override
 	@SecurityTransactional
-	public void execute(String token) {
-		whiteAuthTokenHashRepository.save(WhiteAuthTokenHash.builder().token(token).build());
+	public void execute(String token, Long ttl) {
+		whiteAuthTokenHashRepository.save(WhiteAuthTokenHash.builder().token(token).ttl(ttl).build());
 	}
 
 	@Override
 	public void execute(String accessToken, String refreshToken) {
 		whiteAuthTokenHashRepository.saveAll(
 				List.of(
-						WhiteAuthTokenHash.builder().token(accessToken).build(),
-						WhiteAuthTokenHash.builder().token(refreshToken).build()));
+						WhiteAuthTokenHash.builder().token(accessToken).ttl(accessTokenValidTime).build(),
+						WhiteAuthTokenHash.builder().token(refreshToken).ttl(refreshTokenValidTime).build()));
 	}
 }

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/ReplaceWhiteAccessTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/ReplaceWhiteAccessTokenCacheServiceImpl.java
@@ -10,10 +10,10 @@ import org.springframework.stereotype.Service;
 @Profile("!usecase-test")
 @Service
 @RequiredArgsConstructor
-public class ReplaceWhiteTokenCacheServiceImpl implements ReplaceTokenCacheService {
+public class ReplaceWhiteAccessTokenCacheServiceImpl implements ReplaceTokenCacheService {
 
 	private final EvictWhiteTokenCacheServiceImpl evictTokenCacheService;
-	private final EnrollWhiteTokenCacheServiceImpl enrollTokenCacheService;
+	private final EnrollWhiteAccessTokenCacheServiceImpl enrollTokenCacheService;
 	private final EnrollBlackTokenCacheServiceImpl enrollBlackTokenCacheService;
 
 	@Override

--- a/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/ReplaceWhiteAccessTokenCacheServiceImpl.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/external/security/auth/ReplaceWhiteAccessTokenCacheServiceImpl.java
@@ -3,6 +3,7 @@ package com.zzaug.member.domain.external.security.auth;
 import com.zzaug.security.persistence.transaction.SecurityTransactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Service;
 
@@ -11,6 +12,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class ReplaceWhiteAccessTokenCacheServiceImpl implements ReplaceTokenCacheService {
+
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessTokenValidTime;
 
 	private final EvictWhiteTokenCacheServiceImpl evictTokenCacheService;
 	private final EnrollWhiteAccessTokenCacheServiceImpl enrollTokenCacheService;
@@ -22,8 +26,9 @@ public class ReplaceWhiteAccessTokenCacheServiceImpl implements ReplaceTokenCach
 		log.debug("Evict old token.\ntoken: {}", oldToken);
 		evictTokenCacheService.execute(oldToken);
 		log.debug("Enroll old token to black list.\ntoken: {}", oldToken);
-		enrollBlackTokenCacheService.execute(oldToken);
+		// todo fix
+		enrollBlackTokenCacheService.execute(oldToken, 1000 * 60L);
 		log.debug("Enroll new token.\ntoken: {}", newToken);
-		enrollTokenCacheService.execute(newToken);
+		enrollTokenCacheService.execute(newToken, accessTokenValidTime);
 	}
 }

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/ActiveMemberUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/ActiveMemberUseCase.java
@@ -1,0 +1,48 @@
+package com.zzaug.member.domain.usecase.member;
+
+import static com.zzaug.member.config.MemberSessionConfig.SESSION_NAME_SPACE;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ActiveMemberUseCase {
+
+	private static final String MEMBER_ID_SESSION_KEY = "sessionAttr:memberId";
+	private final RedisIndexedSessionRepository redisIndexedSessionRepository;
+
+	public Set<Long> execute() {
+		Set<Long> memberIds = new HashSet<>();
+		Set<Object> keys = getSessionsKeys();
+		for (Object key : keys) {
+			Long memberId =
+					(Long)
+							redisIndexedSessionRepository
+									.getSessionRedisOperations()
+									.opsForHash()
+									.get(key, MEMBER_ID_SESSION_KEY);
+			memberIds.add(memberId);
+		}
+		return memberIds;
+	}
+
+	private Set<Object> getSessionsKeys() {
+		Set<Object> keys =
+				redisIndexedSessionRepository
+						.getSessionRedisOperations()
+						.opsForList()
+						.getOperations()
+						.keys(SESSION_NAME_SPACE + ":sessions:*");
+		assert keys != null;
+		return keys.stream()
+				.filter(key -> !key.toString().contains("expires"))
+				.collect(Collectors.toSet());
+	}
+}

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/CheckEmailAuthUseCase.java
@@ -68,7 +68,7 @@ public class CheckEmailAuthUseCase {
 	private final AuthTokenValidator authTokenValidator;
 	private final TokenGenerator tokenGenerator;
 	private final BlackTokenAuthCommand blackTokenAuthCommand;
-	private final ReplaceTokenCacheService replaceWhiteTokenCacheServiceImpl;
+	private final ReplaceTokenCacheService replaceWhiteAccessTokenCacheServiceImpl;
 
 	@UseCaseTransactional
 	public CheckEmailAuthUseCaseResponse execute(CheckEmailAuthUseCaseRequest request) {
@@ -175,7 +175,7 @@ public class CheckEmailAuthUseCase {
 						memberContacts.getGithub());
 
 		blackTokenAuthCommand.execute(accessToken, refreshToken);
-		replaceWhiteTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
+		replaceWhiteAccessTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
 
 		publishEvent(memberId, memberAuthentication, email);
 

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/LoginUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/LoginUseCase.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -32,6 +33,9 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class LoginUseCase {
+
+	@Value("${security.jwt.token.validtime.access}")
+	private Long accessTokenValidTime;
 
 	private final AuthenticationDao authenticationDao;
 
@@ -82,7 +86,8 @@ public class LoginUseCase {
 		loginLogCommand.saveLoginLog(memberAuthentication.getMemberId(), userAgent);
 
 		// check duplication
-		enrollWhiteAccessTokenCacheServiceImpl.execute(authToken.getAccessToken());
+		enrollWhiteAccessTokenCacheServiceImpl.execute(
+				authToken.getAccessToken(), accessTokenValidTime);
 
 		publishEvent(memberAuthentication);
 

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/LoginUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/LoginUseCase.java
@@ -45,7 +45,7 @@ public class LoginUseCase {
 	private final ApplicationEventPublisher applicationEventPublisher;
 
 	// security
-	private final EnrollTokenCacheService enrollWhiteTokenCacheServiceImpl;
+	private final EnrollTokenCacheService enrollWhiteAccessTokenCacheServiceImpl;
 
 	@UseCaseTransactional
 	public MemberAuthToken execute(LoginUseCaseRequest request) {
@@ -82,11 +82,12 @@ public class LoginUseCase {
 		loginLogCommand.saveLoginLog(memberAuthentication.getMemberId(), userAgent);
 
 		// check duplication
-		enrollWhiteTokenCacheServiceImpl.execute(authToken.getAccessToken());
+		enrollWhiteAccessTokenCacheServiceImpl.execute(authToken.getAccessToken());
 
 		publishEvent(memberAuthentication);
 
 		return MemberAuthToken.builder()
+				.memberId(memberAuthentication.getMemberId())
 				.accessToken(authToken.getAccessToken())
 				.refreshToken(authToken.getRefreshToken())
 				.build();

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/RenewalTokenUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/RenewalTokenUseCase.java
@@ -42,7 +42,7 @@ public class RenewalTokenUseCase {
 	private final TokenResolver tokenResolver;
 	private final BlackTokenAuthCommand blackTokenAuthCommand;
 	private final EnrollTokenCacheService enrollBlackTokenCacheServiceImpl;
-	private final ReplaceTokenCacheService replaceWhiteTokenCacheServiceImpl;
+	private final ReplaceTokenCacheService replaceWhiteAccessTokenCacheServiceImpl;
 
 	@UseCaseTransactional
 	public MemberAuthToken execute(RenewalTokenUseCaseRequest request) {
@@ -74,9 +74,10 @@ public class RenewalTokenUseCase {
 
 		blackTokenAuthCommand.execute(accessToken, refreshToken);
 		enrollBlackTokenCacheServiceImpl.execute(accessToken, refreshToken);
-		replaceWhiteTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
+		replaceWhiteAccessTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
 
 		return MemberAuthToken.builder()
+				.memberId(memberSource.getId())
 				.accessToken(authToken.getAccessToken())
 				.refreshToken(authToken.getRefreshToken())
 				.build();

--- a/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCase.java
+++ b/be/member-api/src/main/java/com/zzaug/member/domain/usecase/member/UpdateMemberUseCase.java
@@ -48,7 +48,7 @@ public class UpdateMemberUseCase {
 	private final AuthTokenValidator authTokenValidator;
 	private final BlackTokenAuthCommand blackTokenAuthCommand;
 	private final EnrollTokenCacheService enrollBlackTokenCacheServiceImpl;
-	private final ReplaceTokenCacheService replaceWhiteTokenCacheServiceImpl;
+	private final ReplaceTokenCacheService replaceWhiteAccessTokenCacheServiceImpl;
 
 	private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -116,7 +116,7 @@ public class UpdateMemberUseCase {
 
 		blackTokenAuthCommand.execute(accessToken, refreshToken);
 		enrollBlackTokenCacheServiceImpl.execute(accessToken, refreshToken);
-		replaceWhiteTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
+		replaceWhiteAccessTokenCacheServiceImpl.execute(accessToken, authToken.getAccessToken());
 
 		publishEvent(memberId, memberAuthentication);
 

--- a/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberCheckController.java
+++ b/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberCheckController.java
@@ -99,7 +99,7 @@ public class MemberCheckController {
 						.refreshToken(refreshTokenValue)
 						.build();
 		CheckEmailAuthUseCaseResponse response = checkEmailAuthUseCase.execute(useCaseRequest);
-		session.invalidate();
+		session.removeAttribute(SESSION_ID_KEY);
 		return ApiResponseGenerator.success(response, HttpStatus.OK, MessageCode.SUCCESS);
 	}
 }

--- a/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberController.java
+++ b/be/member-api/src/main/java/com/zzaug/member/web/controller/v1/member/MemberController.java
@@ -34,6 +34,7 @@ import com.zzaug.web.support.CookieSameSite;
 import com.zzaug.web.support.MessageCode;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -59,6 +60,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class MemberController {
 
 	private static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+	private static final String MEMBER_ID_SESSION_KEY = "memberId";
 
 	private final CookieGenerator cookieGenerator;
 
@@ -130,6 +132,8 @@ public class MemberController {
 				cookieGenerator.createCookie(
 						CookieSameSite.LAX, REFRESH_TOKEN_COOKIE_NAME, response.getRefreshToken());
 		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
+		HttpSession session = httpServletRequest.getSession();
+		session.setAttribute(MEMBER_ID_SESSION_KEY, response.getMemberId());
 		return ApiResponseGenerator.success(response.toResponse(), HttpStatus.OK, MessageCode.SUCCESS);
 	}
 
@@ -152,6 +156,7 @@ public class MemberController {
 		ResponseCookie clearCookie =
 				cookieGenerator.clearCookie(CookieSameSite.LAX, REFRESH_TOKEN_COOKIE_NAME);
 		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, clearCookie.toString());
+		httpServletRequest.getSession().invalidate();
 		return ApiResponseGenerator.success(HttpStatus.OK, MessageCode.SUCCESS);
 	}
 
@@ -196,6 +201,7 @@ public class MemberController {
 				cookieGenerator.createCookie(
 						CookieSameSite.LAX, REFRESH_TOKEN_COOKIE_NAME, response.getRefreshToken());
 		httpServletResponse.addHeader(HttpHeaders.SET_COOKIE, refreshToken.toString());
+		httpServletRequest.getSession().setAttribute(MEMBER_ID_SESSION_KEY, response.getMemberId());
 		return ApiResponseGenerator.success(response.toResponse(), HttpStatus.OK, MessageCode.SUCCESS);
 	}
 }

--- a/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/security/UMockEnrollTokenCacheService.java
+++ b/be/member-api/src/test/java/com/zzaug/member/domain/usecase/config/mock/security/UMockEnrollTokenCacheService.java
@@ -11,7 +11,7 @@ import org.springframework.context.annotation.Profile;
 public class UMockEnrollTokenCacheService implements EnrollTokenCacheService {
 
 	@Override
-	public void execute(String token) {
+	public void execute(String token, Long ttl) {
 		// Do nothing
 	}
 

--- a/be/security/src/main/java/com/zzaug/security/authentication/token/TokenUserDetailsService.java
+++ b/be/security/src/main/java/com/zzaug/security/authentication/token/TokenUserDetailsService.java
@@ -12,6 +12,7 @@ import com.zzaug.security.redis.auth.WhiteAuthTokenHashRepository;
 import com.zzaug.security.token.TokenResolver;
 import io.jsonwebtoken.Claims;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
@@ -47,7 +48,17 @@ public class TokenUserDetailsService implements UserDetailsService {
 		if (!isWhite) {
 			isValidToken(token);
 			log.debug("Save token to WhiteList. \ntoken: {}", token);
-			whiteAuthTokenHashRepository.save(WhiteAuthTokenHash.builder().token(token).build());
+			Long exp =
+					tokenResolver
+							.resolveExp(token)
+							.orElseThrow(
+									() ->
+											new AccessTokenInvalidException(
+													"Invalid access token. accessToken: " + token));
+			Date now = new Date();
+			long restExp = now.getTime() - exp;
+			whiteAuthTokenHashRepository.save(
+					WhiteAuthTokenHash.builder().token(token).ttl(restExp).build());
 		}
 
 		Claims claims =

--- a/be/security/src/main/java/com/zzaug/security/redis/auth/WhiteAuthTokenHash.java
+++ b/be/security/src/main/java/com/zzaug/security/redis/auth/WhiteAuthTokenHash.java
@@ -23,7 +23,6 @@ public class WhiteAuthTokenHash {
 	@Id private String id;
 	@Indexed private String token;
 
-	@Builder.Default
-	@TimeToLive(unit = TimeUnit.MINUTES)
-	private Long ttl = 5L;
+	@TimeToLive(unit = TimeUnit.MILLISECONDS)
+	private Long ttl;
 }

--- a/be/security/src/main/java/com/zzaug/security/token/TokenResolver.java
+++ b/be/security/src/main/java/com/zzaug/security/token/TokenResolver.java
@@ -13,6 +13,7 @@ public class TokenResolver {
 
 	private static final String MEMBER_ID_CLAIM_KEY = "memberId";
 	private static final String MEMBER_ROLE_CLAIM_KEY = "memberRole";
+	private static final String EXPIRE_TIME_KEY = "exp";
 
 	@Value("${security.jwt.token.secretkey}")
 	private String secretKey;
@@ -55,6 +56,21 @@ public class TokenResolver {
 							.parseClaimsJws(token)
 							.getBody()
 							.get(MEMBER_ROLE_CLAIM_KEY, String.class));
+		} catch (Exception e) {
+			log.warn("Failed to get memberId. token: {}", token);
+			return Optional.empty();
+		}
+	}
+
+	public Optional<Long> resolveExp(String token) {
+		try {
+			return Optional.ofNullable(
+					Jwts.parserBuilder()
+							.setSigningKey(secretKey.getBytes())
+							.build()
+							.parseClaimsJws(token)
+							.getBody()
+							.get(EXPIRE_TIME_KEY, Long.class));
 		} catch (Exception e) {
 			log.warn("Failed to get memberId. token: {}", token);
 			return Optional.empty();


### PR DESCRIPTION
🎫 연관 티켓 
---
#304

🙏 작업
----
- Redis ttl을 활용한 활성 유저 판단 API 구현

💁‍♂️ 어떻게?
----
소켓과 같은 것을 활용하여 활성 유저를 판단할 수도 있지만 그렇게 한다면 프런트에도 추가적인 공수가 필요할 것이라 판단하였습니다.

그렇기에 현 상황에서 공수가 가장 적은 방법을 생각해 보았고 accesstoken의 유효 기간만큼 whitelist에 등록하고 whitelist에 존재하는 멤버를 활성 유저로 판단하는 방법을 선택하였습니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료