### PR TITLE
[BE/#336] Chore: 추가 pinpoint agent와 함께 실행하는 task

### DIFF
--- a/be/member-api/build.gradle
+++ b/be/member-api/build.gradle
@@ -30,3 +30,27 @@ task buildDockerImage {
         }
     }
 }
+
+task runMemberAPIWithPinpointAgent {
+    dependsOn bootJar
+
+    def agentPath = System.getenv("AGENT_PATH")
+    def profiles = System.getenv("PROFILES")
+    def apiPort = System.getenv("API_PORT")
+    def agentId = "member-api"
+    def apiJar = "member-api-0.0.1-SNAPSHOT.jar"
+
+    doLast {
+        exec {
+            workingDir './build/libs'
+            commandLine 'cp', apiJar, 'app.jar'
+        }
+    }
+
+    doLast {
+        exec {
+            workingDir './build/libs'
+            commandLine 'java', '-jar', '-javaagent:' + agentPath, '-Dpinpoint.agentId=' + agentId, '-Dpinpoint.applicationName=' + agentId, '-Dspring.profiles.active=' + profiles, "app.jar", "--server.port=" + apiPort
+        }
+    }
+}

--- a/be/notification-api/build.gradle
+++ b/be/notification-api/build.gradle
@@ -28,3 +28,27 @@ task buildDockerImage {
         }
     }
 }
+
+task runWithNotificationAPIPinpointAgent {
+    dependsOn bootJar
+
+    def agentPath = System.getenv("AGENT_PATH")
+    def profiles = System.getenv("PROFILES")
+    def apiPort = System.getenv("API_PORT")
+    def agentId = "notification-api"
+    def apiJar = "notification-api-0.0.1-SNAPSHOT.jar"
+
+    doLast {
+        exec {
+            workingDir './build/libs'
+            commandLine 'cp', apiJar, 'app.jar'
+        }
+    }
+
+    doLast {
+        exec {
+            workingDir './build/libs'
+            commandLine 'java', '-jar', '-javaagent:' + agentPath, '-Dpinpoint.agentId=' + agentId, '-Dpinpoint.applicationName=' + agentId, '-Dspring.profiles.active=' + profiles,  "app.jar" , "--server.port=" + apiPort
+        }
+    }
+}


### PR DESCRIPTION
🎫 연관 티켓 
---
#336

🙏 작업
----
- Pinpoint를 사용하기 위해 Pinpoint Agent와 함께 실행하는 task를 추가하였습니다.

💁‍♂️ 어떻게?
----
````
$ git clone https://github.com/naver/pinpoint-docker.git
$ cd pinpoint-docker
$ git checkout tags/{tag} # 선택
$ docker-compose pull && docker-compose up -d
````

위 명령을 통해 pinpoint-apm을 도커를 통해 실행 시킵니다.

````
$ wget https://github.com/pinpoint-apm/pinpoint/releases/download/v2.3.3/pinpoint-agent-2.3.3.tar.gz \
&& tar xvfz pinpoint-agent-*.tar.gz \
&& rm pinpoint-agent-*.tar.gz \
&& ln -sf pinpoint-agent-* pinpoint-agent

$ cd pinpoint-agent
$ vi pinpoint-root.config
````

위 명령을 통해 pinpoint agent를 세팅합니다.

이때 다운받은 pinpoint agent의 위치를 AGENT_PATH로 설정합니다.
추가로 PROFILES, API_PORT 환경 변수를 지정하여 task를 실행합니다.

🙈 PR 참고 사항
----

📸 스크린샷
----

🤖 테스트 체크리스트
----
- [ ] 체크 미완료
- [x] 체크 완료